### PR TITLE
New limit extraction script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /CMakeLists.txt*
 /cmake
 /build
+*.pyc
+__init__.py

--- a/Core/interface/ConfigReader.h
+++ b/Core/interface/ConfigReader.h
@@ -1,0 +1,360 @@
+/*! Base class to parse configuration file.
+This file is part of https://github.com/hh-italian-group/AnalysisTools. */
+
+#pragma once
+
+#include <fstream>
+#include <vector>
+#include <set>
+#include <map>
+#include <unordered_map>
+#include <unordered_set>
+#include <functional>
+#include <boost/algorithm/string.hpp>
+
+#include "exception.h"
+#include "EnumNameMap.h"
+#include "TextIO.h"
+
+namespace analysis {
+
+namespace detail {
+
+template<typename T>
+struct ConfigParameterParser {
+    using Value = T;
+    static Value Parse(T& t, const std::string& value, std::istream& s) { s >> t; return t; }
+};
+
+template<>
+struct ConfigParameterParser<std::string> {
+    using Value = std::string;
+    static Value Parse(std::string& t, const std::string& value, std::istream& s) { t = value; return t; }
+};
+
+template<typename T>
+struct ConfigParameterParser<std::vector<T>> {
+    using Value = T;
+    static Value Parse(std::vector<T>& param_vec, const std::string& value, std::istream& s)
+    {
+        T t;
+        ConfigParameterParser<T>::Parse(t, value, s);
+        param_vec.push_back(t);
+        return t;
+    }
+};
+
+template<typename T>
+struct ConfigParameterParser<std::set<T>> {
+    using Value = T;
+    static Value Parse(std::set<T>& param_set, const std::string& value, std::istream& s)
+    {
+        T t;
+        ConfigParameterParser<T>::Parse(t, value, s);
+        if(param_set.count(t))
+            throw exception("Duplicated parameter value.");
+        param_set.insert(t);
+        return t;
+    }
+};
+
+template<typename Key, typename _Value>
+struct ConfigParameterParser<std::map<Key, _Value>> {
+    using Value = _Value;
+    static Value Parse(std::map<Key, Value>& param_map, const std::string& value, std::istream& s)
+    {
+        const size_t pos = value.find_first_of(' ');
+        const std::string k_str = value.substr(0, pos);
+        const std::string v_str = value.substr(pos + 1);
+        Key k;
+        Value v;
+        ConfigParameterParser<Key>::Parse(k, k_str, s);
+        ConfigParameterParser<Value>::Parse(v, v_str, s);
+        if(param_map.count(k))
+            throw exception("Duplicated parameter value.");
+        param_map[k] = v;
+        return v;
+    }
+};
+
+template<typename T, typename Wrapper, bool same = std::is_same<T, Wrapper>::value>
+struct ConfigParameterParserEx {
+    using Value = T;
+    static Value Parse(T& t, const std::string& value, std::istream& s)
+    {
+        Wrapper w;
+        ConfigParameterParser<Wrapper>::Parse(w, value, s);
+        t = w;
+        return t;
+    }
+};
+
+template<typename T, typename Wrapper>
+struct ConfigParameterParserEx<std::vector<T>, Wrapper, false> {
+    using Value = T;
+    static Value Parse(std::vector<T>& param_vec, const std::string& value, std::istream& s)
+    {
+        Wrapper w;
+        ConfigParameterParser<Wrapper>::Parse(w, value, s);
+        const T t = w;
+        param_vec.push_back(t);
+        return t;
+    }
+};
+
+template<typename T>
+struct ConfigParameterParserEx<T, T, true> {
+    using Value = typename ConfigParameterParser<T>::Value;
+    static Value Parse(T& t, const std::string& value, std::istream& s)
+    {
+        return ConfigParameterParser<T>::Parse(t, value, s);
+    }
+};
+
+} // namespace detail
+
+class ConfigEntryReader {
+protected:
+    using ReadCountMap = std::unordered_map<std::string, size_t>;
+    enum class Condition { equal_to, greater_equal, greater, less_equal, less };
+
+    class param_parsed_exception {};
+
+public:
+    ConfigEntryReader()
+    {
+        current_stream.exceptions(std::istringstream::failbit);
+        current_stream >> std::boolalpha;
+    }
+
+    virtual ~ConfigEntryReader() {}
+    virtual void StartEntry(const std::string& name, const std::string& reference_name)
+    {
+        read_params_counts.clear();
+    }
+    virtual void EndEntry() {}
+    virtual void ReadParameter(const std::string& param_name, const std::string& param_value)
+    {
+        current_param_name = param_name;
+        current_param_value = param_value;
+        current_stream.str(param_value);
+        current_stream.seekg(0);
+        try {
+            ReadParameter(param_name, param_value, current_stream);
+            throw analysis::exception("Unsupported parameter '%1%'.") % param_name;
+        } catch(param_parsed_exception&) {
+            ++read_params_counts[param_name];
+        }
+    }
+
+    static std::vector<std::string> ParseOrderedParameterList(std::string param_list,
+                                                              bool allow_duplicates = false,
+                                                              const std::string& separators = " \t")
+    {
+        return SplitValueList(param_list, allow_duplicates, separators, true);
+    }
+
+    static std::unordered_set<std::string> ParseParameterList(const std::string& param_list,
+                                                              const std::string& separators = " \t")
+    {
+        const std::vector<std::string> ordered_result = ParseOrderedParameterList(param_list, false, separators);
+        return std::unordered_set<std::string>(ordered_result.begin(), ordered_result.end());
+    }
+
+protected:
+    virtual void ReadParameter(const std::string& param_name, const std::string& param_value,
+                               std::istringstream& ss) = 0;
+
+    template<typename T, typename Wrapper = T,
+             typename ValidityCheck = std::function<bool(const typename detail::ConfigParameterParser<T>::Value&)>>
+    void ParseEntry(const std::string& name, T& result, const ValidityCheck& validity_check)
+    {
+        using Parser = detail::ConfigParameterParserEx<T, Wrapper>;
+        if(name != current_param_name) return;
+        const auto& v = Parser::Parse(result, current_param_value, current_stream);
+        if(!validity_check(v))
+            throw exception("Parameter '%1%' = '%2%' is outside of its validity range.")
+                % current_param_name % current_param_value;
+        throw param_parsed_exception();
+    }
+
+    template<typename T, typename Wrapper = T>
+    void ParseEntry(const std::string& name, T& result)
+    {
+        const auto validity_check = [](const typename detail::ConfigParameterParser<T>::Value&) { return true; };
+        ParseEntry<T, Wrapper>(name, result, validity_check);
+    }
+
+    template<typename T>
+    void ParseEntryList(const std::string& name, std::vector<T>& result, bool allow_duplicates,
+                        const std::string& separators,
+                        std::function<bool(const typename detail::ConfigParameterParser<T>::Value&)> validity_check)
+    {
+        if(name != current_param_name) return;
+        const auto param_list = ParseOrderedParameterList(current_param_value, allow_duplicates, separators);
+        for(const std::string& param_value : param_list) {
+            std::istringstream ss(param_value);
+            ss.exceptions(std::istringstream::failbit);
+            ss >> std::boolalpha;
+            T value;
+            const auto& v = detail::ConfigParameterParser<T>::Parse(value, param_value, ss);
+            if(!validity_check(v))
+                throw exception("One of parameters in '%1%' equals '%2%', which is outside of its validity range.")
+                    % current_param_name % param_value;
+            result.push_back(value);
+        }
+
+        throw param_parsed_exception();
+    }
+
+    template<typename T>
+    void ParseEntryList(const std::string& name, std::vector<T>& result, bool allow_duplicates = false,
+                        const std::string& separators = " \t")
+    {
+        const auto validity_check = [](const typename detail::ConfigParameterParser<T>::Value&) { return true; };
+        ParseEntryList<T>(name, result, allow_duplicates, separators, validity_check);
+    }
+
+    void CheckReadParamCounts(const std::string& param_name, size_t expected, Condition condition) const
+    {
+        static const std::map<Condition, std::pair<std::string, std::function<bool(size_t, size_t)>>> conditions {
+            { Condition::equal_to, { "exactly", std::equal_to<size_t>() } },
+            { Condition::greater_equal, { "at least", std::greater_equal<size_t>() } },
+            { Condition::greater, { "more than", std::greater<size_t>() } },
+            { Condition::less_equal, { "less than", std::less_equal<size_t>() } },
+            { Condition::less, { "no more than", std::less<size_t>() } }
+        };
+
+        const size_t count = read_params_counts.count(param_name) ? read_params_counts.at(param_name) : 0;
+        const std::string cmp_string = conditions.at(condition).first;
+        const auto& cond_operator = conditions.at(condition).second;
+        if(!cond_operator(count, expected))
+            throw analysis::exception("The number of occurrences of the parameter '%1%' is %2%,"
+                                      " while expected %3% %4%.") % param_name % count % cmp_string % expected;
+    }
+
+private:
+    ReadCountMap read_params_counts;
+    std::string current_param_name, current_param_value;
+    std::istringstream current_stream;
+};
+
+class ConfigReader {
+private:
+    using EntryReaderMap = std::unordered_map<std::string, ConfigEntryReader*>;
+    using EntryNameMap = std::unordered_map<std::string, std::unordered_set<std::string>>;
+
+public:
+    ConfigReader() : defaultEntryReader(entryReaderMap.end()) {}
+
+    void AddEntryReader(const std::string& name, ConfigEntryReader& entryReader, bool isDefault = true)
+    {
+        if(entryReaderMap.count(name))
+            throw analysis::exception("Entry reader with name '%1%' is already defined.") % name;
+        entryReaderMap[name] = &entryReader;
+        if(isDefault) {
+            if(defaultEntryReader != entryReaderMap.end())
+                throw analysis::exception("Default entry reader is already set.");
+            defaultEntryReader = entryReaderMap.find(name);
+        }
+    }
+
+    void ReadConfig(const std::string& _configName)
+    {
+        configName = _configName;
+        if(defaultEntryReader == entryReaderMap.end())
+            throw analysis::exception("Default entry reader is not set.");
+        readEntryNames.clear();
+        std::ifstream cfg(configName);
+        if(cfg.fail())
+            throw analysis::exception("Failed to open config file '%1%'.") % configName;
+        size_t line_number = 0;
+        EntryReaderMap::const_iterator entryReader = entryReaderMap.end();
+        while(ReadNextEntry(cfg, line_number, entryReader)) {
+            try {
+                entryReader->second->EndEntry();
+            } catch(std::exception& e) {
+                BadSyntax(line_number, e.what());
+            }
+        }
+    }
+
+private:
+    bool ReadNextEntry(std::istream& cfg, size_t& line_number, EntryReaderMap::const_iterator& entryReader)
+    {
+        bool entry_started = false;
+        while (cfg.good()) {
+            std::string cfgLine;
+            std::getline(cfg, cfgLine);
+            ++line_number;
+            if ((cfgLine.size() && cfgLine.at(0) == '#') || (!cfgLine.size() && !entry_started)) continue;
+            if(!cfgLine.size())
+                return true;
+            if(!entry_started && cfgLine.at(0) == '[') {
+                const size_t end_pos = cfgLine.find(']');
+                CheckSyntax(end_pos != std::string::npos, line_number);
+                const std::string entry_definition = cfgLine.substr(1, end_pos - 1);
+                std::vector<std::string> entry_parameters;
+                boost::split(entry_parameters, entry_definition, boost::is_any_of(" "), boost::token_compress_on);
+                CheckSyntax(entry_parameters.size() >= 1 && entry_parameters.size() <= 4, line_number);
+                CheckSyntax(entry_parameters.size() < 3
+                            || entry_parameters.at(entry_parameters.size() - 2) == ":", line_number);
+
+                const std::string name = entry_parameters.at((entry_parameters.size() - 1) % 2);
+                const std::string reader_name = entry_parameters.size() % 2 ?
+                            defaultEntryReader->first : entry_parameters.at(0);
+                const std::string reference_name = entry_parameters.size() > 2 ? entry_parameters.back() : "";
+
+                CheckSyntax(entryReaderMap.count(reader_name), line_number, "Unknown entry type");
+                entryReader = entryReaderMap.find(reader_name);
+
+
+                CheckSyntax(!readEntryNames[entryReader->first].count(name), line_number,
+                            boost::str(boost::format("Redifinition of the entry with a name '%1%'.") % name));
+                CheckSyntax(!reference_name.size() || readEntryNames[entryReader->first].count(reference_name),
+                        line_number, boost::str(boost::format("Reference entry '%1%' not found.") % reference_name));
+                readEntryNames.at(entryReader->first).insert(name);
+                entryReader->second->StartEntry(name, reference_name);
+                entry_started = true;
+            } else if(entry_started) {
+                ReadParameterLine(cfgLine, line_number, *entryReader->second);
+            } else
+                BadSyntax(line_number);
+        }
+        return entry_started;
+    }
+
+    void ReadParameterLine(const std::string& cfgLine, size_t line_number, ConfigEntryReader& entryReader) const
+    {
+        static const char separator = ':';
+
+        const size_t pos = cfgLine.find(separator);
+        CheckSyntax(pos != std::string::npos && pos + 2 < cfgLine.size(), line_number);
+        const std::string param_name = cfgLine.substr(0, pos);
+        const std::string param_value = cfgLine.substr(pos + 2);
+        try {
+            entryReader.ReadParameter(param_name, param_value);
+        } catch(std::exception& e) {
+            BadSyntax(line_number, e.what());
+        }
+    }
+
+    void CheckSyntax(bool condition, size_t line_number, const std::string& message = "") const
+    {
+        if(!condition)
+            BadSyntax(line_number, message);
+    }
+
+    void BadSyntax(size_t line_number, const std::string& message = "") const
+    {
+        throw analysis::exception("Bad config syntax: file '%1%' line %2%.\n%3%") % configName % line_number % message;
+    }
+
+private:
+    std::string configName;
+    EntryReaderMap entryReaderMap;
+    EntryReaderMap::const_iterator defaultEntryReader;
+    EntryNameMap readEntryNames;
+};
+
+} // namespace analysis

--- a/Core/interface/EnumNameMap.h
+++ b/Core/interface/EnumNameMap.h
@@ -1,0 +1,157 @@
+/*! Definition of the I/O operators for enum <-> string conversion.
+This file is part of https://github.com/hh-italian-group/AnalysisTools. */
+
+#pragma once
+
+#include<istream>
+#include<ostream>
+#include<unordered_set>
+#include<unordered_map>
+#include<initializer_list>
+#include<typeinfo>
+
+#include "exception.h"
+
+#define ENUM_NAMES(enum_type) \
+    template<typename T=void> \
+    struct __##enum_type##_names { static const ::analysis::EnumNameMap<enum_type> names; }; \
+	struct __##enum_type##_names_impl : __##enum_type##_names<> { const ::analysis::EnumNameMap<enum_type>* names_ptr = &names;  }; \
+    template<typename T> \
+    const ::analysis::EnumNameMap<enum_type> __##enum_type##_names<T>::names
+
+#define ENUM_OSTREAM_OPERATORS() \
+    template<typename Enum, typename = typename std::enable_if<std::is_enum<Enum>::value>::type> \
+    inline std::ostream& operator<<(std::ostream& os, Enum e) { return ::analysis::operator <<(os, e); } \
+    template<typename Enum, typename = typename std::enable_if<std::is_enum<Enum>::value>::type> \
+    inline std::wostream& operator<<(std::wostream& os, Enum e) { return ::analysis::operator <<(os, e); } \
+    /**/
+
+#define ENUM_ISTREAM_OPERATORS() \
+    template<typename Enum, typename = typename std::enable_if<std::is_enum<Enum>::value>::type> \
+    inline std::istream& operator>>(std::istream& is, Enum& e) { return ::analysis::operator >>(is, e); } \
+    template<typename Enum, typename = typename std::enable_if<std::is_enum<Enum>::value>::type> \
+    inline std::wistream& operator>>(std::wistream& is, Enum& e) { return ::analysis::operator >>(is, e); } \
+    /**/
+
+namespace analysis {
+template<typename Enum>
+class EnumNameMap {
+public:
+    using EnumStringPair = std::pair<Enum, std::string>;
+    struct EnumHash {
+        size_t operator()(const Enum& e) const { std::hash<size_t> h; return h(static_cast<size_t>(e)); }
+    };
+    using EnumEntrySet = std::unordered_set<Enum, EnumHash>;
+    using StringEntrySet = std::unordered_set<std::string>;
+
+    EnumNameMap(const std::string& _enum_name, const std::initializer_list<EnumStringPair>& pairs)
+        : enum_name(_enum_name)
+    {
+        Initialize(pairs);
+    }
+
+    EnumNameMap(const std::initializer_list<EnumStringPair>& pairs)
+        : enum_name(typeid(Enum).name())
+    {
+        if(GetDefault(false))
+            throw exception("Redefinition of enum names for the enum '%1%'") % enum_name;
+        GetDefault(false) = this;
+        Initialize(pairs);
+    }
+
+    bool HasEnum(const Enum& e) const { return enum_to_string_map.count(e); }
+    bool HasString(const std::string& str) const { return string_to_enum_map.count(str); }
+
+    const std::string& EnumToString(const Enum& e) const
+    {
+        if(!HasEnum(e))
+            throw exception("The corresponding string is not found for an element of the enum '%1%'.") % enum_name;
+        return enum_to_string_map.at(e);
+    }
+
+    bool TryParse(const std::string& str, Enum& e) const
+    {
+        if(!HasString(str))
+            return false;
+        e = string_to_enum_map.at(str);
+        return true;
+    }
+
+    Enum Parse(const std::string& str) const
+    {
+        Enum e;
+        if(!TryParse(str, e))
+            throw exception("An element of the enum '%1%' that corresponds to the string '%2%' is not found.")
+                % enum_name % str;
+        return e;
+    }
+
+    const EnumEntrySet& GetEnumEntries() const { return enum_entries; }
+    const StringEntrySet& GetStringEntries() const { return string_entries; }
+
+    static const EnumNameMap<Enum>& GetDefault() { return *GetDefault(true); }
+
+private:
+    void Initialize(const std::initializer_list<EnumStringPair>& pairs)
+    {
+        for(const EnumStringPair& entry : pairs) {
+            if(enum_to_string_map.count(entry.first) || string_to_enum_map.count(entry.second))
+                throw exception("Duplicated enum entry for the enum '%1%'.") % enum_name;
+            enum_to_string_map[entry.first] = entry.second;
+            string_to_enum_map[entry.second] = entry.first;
+            enum_entries.insert(entry.first);
+            string_entries.insert(entry.second);
+        }
+    }
+
+    static EnumNameMap<Enum>*& GetDefault(bool null_check)
+    {
+        static EnumNameMap<Enum>* m = nullptr;
+        if(null_check && !m)
+            throw exception("Names for the enum '%1%' are not defined.") % typeid(Enum).name();
+        return m;
+    }
+
+private:
+    std::string enum_name;
+    std::unordered_map<Enum, std::string, EnumHash> enum_to_string_map;
+    std::unordered_map<std::string, Enum> string_to_enum_map;
+    EnumEntrySet enum_entries;
+    StringEntrySet string_entries;
+};
+
+template<typename Enum, typename = typename std::enable_if<std::is_enum<Enum>::value>::type>
+std::ostream& operator<<(std::ostream& os, Enum e)
+{
+    os << analysis::EnumNameMap<Enum>::GetDefault().EnumToString(e);
+    return os;
+}
+
+template<typename Enum, typename = typename std::enable_if<std::is_enum<Enum>::value>::type>
+std::wostream& operator<<(std::wostream& os, Enum e)
+{
+    const std::string str = analysis::EnumNameMap<Enum>::GetDefault().EnumToString(e);
+    os << std::wstring(str.begin(), str.end());
+    return os;
+}
+
+template<typename Enum, typename = typename std::enable_if<std::is_enum<Enum>::value>::type>
+std::istream& operator>>(std::istream& is, Enum& e)
+{
+    std::string str;
+    is >> str;
+    e = analysis::EnumNameMap<Enum>::GetDefault().Parse(str);
+    return is;
+}
+
+template<typename Enum, typename = typename std::enable_if<std::is_enum<Enum>::value>::type>
+std::wistream& operator>>(std::wistream& is, Enum& e)
+{
+    std::wstring wstr;
+    is >> wstr;
+    const std::string str(wstr.begin(), wstr.end());
+    e = analysis::EnumNameMap<Enum>::GetDefault().Parse(str);
+    return is;
+}
+
+} // namespace analysis

--- a/Core/interface/NumericPrimitives.h
+++ b/Core/interface/NumericPrimitives.h
@@ -1,0 +1,443 @@
+/*! Definition of the primitives that extend CERN ROOT functionality.
+This file is part of https://github.com/hh-italian-group/AnalysisTools. */
+
+#pragma once
+
+#include <type_traits>
+#include <boost/math/constants/constants.hpp>
+#include <TF1.h>
+#include "TextIO.h"
+
+namespace analysis {
+
+namespace detail {
+    template<typename T, bool fundamental = std::is_fundamental<T>::value>
+    struct ConstRefType;
+
+    template<typename T>
+    struct ConstRefType<T, true> { using Type = T; };
+
+    template<typename T>
+    struct ConstRefType<T, false> { using Type = const T&; };
+}
+
+template<typename T>
+struct Range {
+    using ValueType = T;
+    using ConstRefType = typename detail::ConstRefType<T>::Type;
+    Range() : _min(0), _max(0) {}
+    Range(ConstRefType min, ConstRefType max) : _min(min), _max(max)
+    {
+        if(!IsValid(min, max))
+            throw exception("Invalid range [%1%, %2%].") % min % max;
+    }
+    virtual ~Range() {}
+
+    ConstRefType min() const { return _min; }
+    ConstRefType max() const { return _max; }
+    T size() const { return max() - min(); }
+    bool Contains(ConstRefType v) const { return v >= min() && v <= max(); }
+    static bool IsValid(ConstRefType min, ConstRefType max) { return min <= max; }
+
+    Range<T> Extend(ConstRefType v) const
+    {
+        if(Contains(v))
+            return *this;
+        return Range<T>(std::min(min(), v), std::max(max(), v));
+    }
+
+    bool Includes(const Range<T>& other) const { return min() <= other.min() && max() >= other.max(); }
+    bool Overlaps(const Range<T>& other) const { return min() <= other.max() && other.min() <= max();  }
+    Range<T> Combine(const Range<T>& other) const
+    {
+        if(!Overlaps(other))
+            throw exception("Unable to combine non overlapping ranges.");
+        return Range<T>(std::min(min(), other.min()), std::max(max(), other.max()));
+    }
+
+    std::string ToString(char sep = ' ') const
+    {
+        std::ostringstream ss;
+        ss << min() << sep << max();
+        return ss.str();
+    }
+
+    static Range<T> Parse(const std::string& str, const std::string& separators=": \n")
+    {
+        const auto values = SplitValueList(str, true, separators, true);
+        if(values.size() != 2)
+            throw exception("Invalid range '%1%'.") % str;
+        return Make(values);
+    }
+
+    static Range<T> Read(std::istream& stream, const std::string& separators=": \n")
+    {
+        const auto values = ReadValueList(stream, 2, true, separators, true);
+        return Make(values);
+    }
+
+private:
+    static Range<T> Make(const std::vector<std::string>& values)
+    {
+        const T min = ::analysis::Parse<T>(values.at(0));
+        const T max = ::analysis::Parse<T>(values.at(1));
+        return Range<T>(min, max);
+    }
+
+private:
+    T _min, _max;
+};
+
+template<typename T>
+std::ostream& operator<<(std::ostream& s, const Range<T>& r)
+{
+    s << r.ToString(':');
+    return s;
+}
+
+template<typename T>
+std::istream& operator>>(std::istream& s, Range<T>& r)
+{
+    r = Range<T>::Read(s);
+    return s;
+}
+
+template<typename T>
+struct RelativeRange {
+    using ValueType = T;
+    using ConstRefType = typename detail::ConstRefType<T>::Type;
+    RelativeRange() : _down(0), _up(0) {}
+    RelativeRange(ConstRefType down, ConstRefType up) : _down(down), _up(up)
+    {
+        if(!IsValid(down, up))
+            throw exception("Invalid relative range [%1%, %2%].") % down % up;
+    }
+
+    ConstRefType down() const { return _down; }
+    ConstRefType up() const { return _up; }
+    Range<T> ToAbsoluteRange(ConstRefType v) const { return Range<T>(v + down(), v + up()); }
+    static bool IsValid(ConstRefType down, ConstRefType up) { return down <= 0 && up >= 0; }
+
+    std::string ToString(char sep = ' ') const
+    {
+        std::ostringstream ss;
+        ss << down() << sep << up();
+        return ss.str();
+    }
+
+    static RelativeRange<T> Parse(const std::string& str, const std::string& separators=": \n")
+    {
+        const auto values = SplitValueList(str, true, separators, true);
+        if(values.size() != 2)
+            throw exception("Invalid relative range '%1%'.") % str;
+        return Make(values);
+    }
+
+    static RelativeRange<T> Read(std::istream& stream, const std::string& separators=": \n")
+    {
+        const auto values = ReadValueList(stream, 2, true, separators, true);
+        return Make(values);
+    }
+
+private:
+    static RelativeRange<T> Make(const std::vector<std::string>& values)
+    {
+        const T down = ::analysis::Parse<T>(values.at(0));
+        const T up = ::analysis::Parse<T>(values.at(1));
+        return RelativeRange<T>(down, up);
+    }
+
+private:
+    T _down, _up;
+};
+
+template<typename T>
+std::ostream& operator<<(std::ostream& s, const RelativeRange<T>& r)
+{
+    s << r.ToString(':');
+    return s;
+}
+
+template<typename T>
+std::istream& operator>>(std::istream& s, RelativeRange<T>& r)
+{
+    r = RelativeRange<T>::Read(s);
+    return s;
+}
+
+template<typename T>
+struct RangeWithStep : public Range<T> {
+    using ValueType = typename Range<T>::ValueType;
+    using ConstRefType = typename Range<T>::ConstRefType;
+
+    RangeWithStep() : _step(0) {}
+    RangeWithStep(ConstRefType min, ConstRefType max, ConstRefType step) : Range<T>(min, max), _step(step) {}
+
+    ConstRefType step() const { return _step; }
+    size_t n_bins() const { return (this->max() - this->min()) / step(); }
+
+    std::string ToString(char sep = ' ') const
+    {
+        std::ostringstream ss;
+        ss << this->min() << sep << this->max() << sep << step();
+        return ss.str();
+    }
+
+    static RangeWithStep<T> Parse(const std::string& str, const std::string& separators=": \n")
+    {
+        const auto values = SplitValueList(str, true, separators, true);
+        if(values.size() != 3)
+            throw exception("Invalid range with step '%1%'.") % str;
+        return Make(values);
+    }
+
+    static RangeWithStep<T> Read(std::istream& stream, const std::string& separators=": \n")
+    {
+        const auto values = ReadValueList(stream, 3, true, separators, true);
+        return Make(values);
+    }
+
+private:
+    static RangeWithStep<T> Make(const std::vector<std::string>& values)
+    {
+        const T min = ::analysis::Parse<T>(values.at(0));
+        const T max = ::analysis::Parse<T>(values.at(1));
+        const T step = ::analysis::Parse<T>(values.at(2));
+        return RangeWithStep<T>(min, max, step);
+    }
+
+private:
+    T _step;
+};
+
+template<typename T>
+std::ostream& operator<<(std::ostream& s, const RangeWithStep<T>& r)
+{
+    s << r.ToString(':');
+    return s;
+}
+
+template<typename T>
+std::istream& operator>>(std::istream& s, RangeWithStep<T>& r)
+{
+    r = RangeWithStep<T>::Read(s);
+    return s;
+}
+
+template<unsigned n_pi_per_period_num, unsigned n_pi_per_period_denom = 1>
+struct Angle {
+    enum class Interval { Symmetric, Positive };
+    static constexpr double Pi() { return boost::math::constants::pi<double>(); }
+    static constexpr double NumberOfPiPerPeriod() { return double(n_pi_per_period_num) / n_pi_per_period_denom; }
+    static constexpr double FullPeriod() { return n_pi_per_period_num * Pi() / n_pi_per_period_denom; }
+    static constexpr double HalfPeriod() { return FullPeriod() / 2; }
+
+    Angle() : _value(0), _interval(Interval::Symmetric) {}
+    Angle(double value, Interval interval = Interval::Symmetric)
+        : _value(AdjustValue(value, interval)), _interval(interval) {}
+
+    double value() const { return _value; }
+    Interval interval() const { return _interval; }
+
+    Angle operator+(const Angle& other) const { return Angle(value() + other.value(), interval()); }
+    Angle operator-(const Angle& other) const { return Angle(value() - other.value(), interval()); }
+
+    static const Range<double>& AngleValuesRange(Interval interval)
+    {
+        static const std::map<Interval, Range<double>> range_map = {
+            { Interval::Symmetric, { -HalfPeriod(), HalfPeriod() } },
+            { Interval::Positive, { 0, FullPeriod() } }
+        };
+        return range_map.at(interval);
+    }
+
+    static double AdjustValue(double value, Interval interval)
+    {
+        const Range<double>& range = AngleValuesRange(interval);
+        value -= FullPeriod() * std::floor(value/FullPeriod());
+        while(value < range.min() || value >= range.max())
+            value += value < range.min() ? FullPeriod() : -FullPeriod();
+        return value;
+    }
+
+private:
+    double _value;
+    Interval _interval;
+};
+
+template<unsigned n_pi_per_period_num, unsigned n_pi_per_period_denom>
+std::ostream& operator<<(std::ostream& s, const Angle<n_pi_per_period_num, n_pi_per_period_denom>& a)
+{
+    s << a.value();
+    return s;
+}
+
+template<unsigned n_pi_per_period_num, unsigned n_pi_per_period_denom>
+std::istream& operator>>(std::istream& s, const Angle<n_pi_per_period_num, n_pi_per_period_denom>& a)
+{
+    double value;
+    s >> value;
+    a = Angle<n_pi_per_period_num, n_pi_per_period_denom>(value);
+    return s;
+}
+
+template<unsigned n_pi_per_period_num, unsigned n_pi_per_period_denom>
+struct Range<Angle<n_pi_per_period_num, n_pi_per_period_denom>> {
+    using A = Angle<n_pi_per_period_num, n_pi_per_period_denom>;
+    using ValueType = A;
+
+    Range() : _min(0), _max(0) {}
+    Range(const A& min, const A& max) : _min(min), _max(max.value(), min.interval()) {}
+    virtual ~Range() {}
+
+    const A& min() const { return _min; }
+    const A& max() const { return _max; }
+    A size() const { return A(_max.value() - _min.value(), A::Interval::Positive); }
+    Range<double> ToValueRange() const
+    {
+        const double min_value = min().value();
+        double max_value = max().value();
+        if(max_value < min_value)
+            max_value += A::FullPeriod();
+        return Range<double>(min_value, max_value);
+    }
+
+    bool Contains(const A& a) const
+    {
+        const Range<double> min_a_value_range = Range<A>(min(), a).ToValueRange();
+        return ToValueRange().Contains(min_a_value_range.max());
+    }
+
+    static bool IsValid(const A& min, const A& max) { return true; }
+
+    Range<A> Extend(const A& a) const
+    {
+        if(Contains(a))
+            return *this;
+        const A a_fixed(a.value(), min().interval());
+        const Range<A> extend_min(a_fixed, max()), extend_max(min(), a_fixed);
+        return extend_max.size().value() < extend_min.size().value() ? extend_max : extend_min;
+    }
+
+    bool Includes(const Range<A>& other) const
+    {
+        return Contains(other.min()) && Contains(other.max());
+    }
+
+    bool Overlaps(const Range<A>& other) const
+    {
+        return Contains(other.min()) || Contains(other.max()) || other.Contains(min());
+    }
+
+    Range<A> Combine(const Range<A>& other) const
+    {
+        if(!Overlaps(other))
+            throw exception("Unable to combine non overlapping ranges.");
+        if(Includes(other))
+            return *this;
+        if(other.Includes(*this))
+            return other;
+        if(Contains(other.min()))
+            return Range<A>(min(), other.max());
+        return Range<A>(other.min(), max());
+    }
+    std::string ToString(char sep = ' ') const
+    {
+        std::ostringstream ss;
+        ss << min() << sep << max();
+        return ss.str();
+    }
+
+    static Range<A> Parse(const std::string& str, const std::string& separators=": \n")
+    {
+        const auto values = SplitValueList(str, true, separators, true);
+        if(values.size() != 2)
+            throw exception("Invalid angle range '%1%'.") % str;
+        return Make(values);
+    }
+
+    static Range<A> Read(std::istream& stream, const std::string& separators=": \n")
+    {
+        const auto values = ReadValueList(stream, 2, true, separators, true);
+        return Make(values);
+    }
+
+private:
+    static Range<A> Make(const std::vector<std::string>& values)
+    {
+        const A min = ::analysis::Parse<A>(values.at(0));
+        const A max = ::analysis::Parse<A>(values.at(1));
+        return Range<A>(min, max);
+    }
+
+private:
+    A _min, _max;
+};
+
+template<typename Range>
+struct RangeMultiD {
+public:
+    using ValueType = typename Range::ValueType;
+    explicit RangeMultiD(size_t n_dim) : ranges(n_dim) {}
+    explicit RangeMultiD(const std::vector<Range>& _ranges) : ranges(_ranges) {}
+
+    size_t GetNumberOfDimensions() const { return ranges.size(); }
+    const Range& GetRange(size_t dim_id) const { Check(dim_id); return ranges.at(dim_id - 1); }
+    Range& GetRange(size_t dim_id) { Check(dim_id); return ranges.at(dim_id - 1); }
+
+    bool Contains(const std::vector<ValueType>& point) const
+    {
+        if(point.size() != GetNumberOfDimensions())
+            throw exception("Invalid number of dimensions.");
+        for(size_t n = 0; n < ranges.size(); ++n)
+            if(!ranges.at(n).Contains(point.at(n))) return false;
+        return true;
+    }
+
+private:
+    void Check(size_t dim_id) const
+    {
+        if(!dim_id || dim_id > GetNumberOfDimensions())
+            throw exception("Wrong dimension id = %1%") % dim_id;
+    }
+
+private:
+    std::vector<Range> ranges;
+};
+
+struct NumericalExpression {
+    NumericalExpression() : _value(0) {}
+    NumericalExpression(const std::string& expression)
+        : _expression(expression)
+    {
+        const std::string formula = boost::str(boost::format("x*(%1%)") % expression);
+        TF1 fn("", formula.c_str(), 0, 1);
+//        if(!fn.IsValid())
+//            throw exception("Invalid numerical expression '%1%'") % expression;
+        _value = fn.Eval(1);
+    }
+
+    const std::string& expression() const { return _expression; }
+    double value() const { return _value; }
+    operator double() const { return _value; }
+
+private:
+    std::string _expression;
+    double _value;
+};
+
+inline std::ostream& operator<<(std::ostream& s, const NumericalExpression& e)
+{
+    s << e.expression();
+    return s;
+}
+
+inline std::istream& operator>>(std::istream& s, NumericalExpression& e)
+{
+    std::string line;
+    std::getline(s, line);
+    e = NumericalExpression(line);
+    return s;
+}
+
+} // namespace analysis

--- a/Core/interface/PlotPrimitives.h
+++ b/Core/interface/PlotPrimitives.h
@@ -1,0 +1,490 @@
+/*! Definition of the plot primitives.
+This file is part of https://github.com/hh-italian-group/AnalysisTools. */
+
+#pragma once
+
+#include <sstream>
+#include <boost/regex.hpp>
+#include <boost/algorithm/string.hpp>
+#include <TROOT.h>
+#include <TColor.h>
+#include <TAttText.h>
+#include "EnumNameMap.h"
+#include "NumericPrimitives.h"
+
+namespace root_ext {
+
+template<typename T, size_t n_dim, bool positively_defined = false>
+struct Point;
+
+template<typename T, bool positively_defined>
+struct Point<T, 1, positively_defined> {
+    Point() : _x(0) {}
+    Point(const T& x)
+        : _x(x)
+    {
+        if(!IsValid(x))
+            throw analysis::exception("Invalid point %1%.") % x;
+    }
+
+    const T& x() const { return _x; }
+    operator T() const { return _x; }
+    Point<T, 1, positively_defined> operator+(const Point<T, 1, positively_defined>& other) const
+    {
+        return Point<T, 1, positively_defined>(x() + other.x());
+    }
+    Point<T, 1, positively_defined> operator-(const Point<T, 1, positively_defined>& other) const
+    {
+        return Point<T, 1, positively_defined>(x() - other.x());
+    }
+    Point<T, 1, positively_defined> operator*(const Point<T, 1, positively_defined>& other) const
+    {
+        return Point<T, 1, positively_defined>(x() * other.x());
+    }
+
+    static bool IsValid(const T& x) { return !positively_defined || x >= 0; }
+
+private:
+    T _x;
+};
+
+template<typename T, bool positively_defined>
+struct Point<T, 2, positively_defined> {
+    Point() : _x(0), _y(0) {}
+    Point(const T& x, const T& y)
+        : _x(x), _y(y)
+    {
+        if(!IsValid(x, y))
+            throw analysis::exception("Invalid point (%1%, %2%).") % x % y;
+    }
+
+    const T& x() const { return _x; }
+    const T& y() const { return _y; }
+    Point<T, 2, positively_defined> operator+(const Point<T, 2, positively_defined>& other) const
+    {
+        return Point<T, 2, positively_defined>(x() + other.x(), y() + other.y());
+    }
+    Point<T, 2, positively_defined> operator-(const Point<T, 2, positively_defined>& other) const
+    {
+        return Point<T, 2, positively_defined>(x() - other.x(), y() - other.y());
+    }
+    Point<T, 2, positively_defined> operator*(const Point<T, 2, positively_defined>& other) const
+    {
+        return Point<T, 2, positively_defined>(x() * other.x(), y() * other.y());
+    }
+
+    Point<T, 2, positively_defined> flip_x() const { return Point<T, 2, positively_defined>(-x(), y()); }
+    Point<T, 2, positively_defined> flip_y() const { return Point<T, 2, positively_defined>(x(), -y()); }
+
+    static bool IsValid(const T& x, const T& y) { return !positively_defined || (x >= 0 && y >= 0); }
+
+private:
+    T _x, _y;
+};
+
+template<typename T, bool positively_defined>
+std::ostream& operator<<(std::ostream& s, const Point<T, 2, positively_defined>& p)
+{
+    s << boost::format("%1% %2%") % p.x() % p.y();
+    return s;
+}
+
+template<typename T, bool positively_defined>
+std::istream& operator>>(std::istream& s, Point<T, 2, positively_defined>& p)
+{
+    T x, y;
+    s >> x >> y;
+    if(s.fail())
+        throw analysis::exception("Invalid point.");
+    p = Point<T, 2, positively_defined>(x, y);
+    return s;
+}
+
+template<typename T, bool positively_defined>
+std::ostream& operator<<(std::ostream& s, const Point<T, 1, positively_defined>& p)
+{
+    s << p.x();
+    return s;
+}
+
+template<typename T, bool positively_defined>
+std::istream& operator>>(std::istream& s, Point<T, 1, positively_defined>& p)
+{
+    T x;
+    s >> x;
+    if(s.fail())
+        throw analysis::exception("Invalid point.");
+    p = Point<T, 1, positively_defined>(x);
+    return s;
+}
+
+
+template<typename T>
+struct Box {
+    using Position = Point<T, 2>;
+    Box() {}
+
+    Box(const Position& left_bottom, const Position& right_top) : _left_bottom(left_bottom), _right_top(right_top)
+    {
+        CheckValidity();
+    }
+
+    Box(const T& left_bottom_x, const T& left_bottom_y, const T& right_top_x, const T& right_top_y)
+        : _left_bottom(left_bottom_x, left_bottom_y), _right_top(right_top_x, right_top_y)
+    {
+        CheckValidity();
+    }
+
+    const Position& left_bottom() const { return _left_bottom; }
+    const Position& right_top() const { return _right_top; }
+    const T& left_bottom_x() const { return left_bottom().x(); }
+    const T& left_bottom_y() const { return left_bottom().y(); }
+    const T& right_top_x() const { return right_top().x(); }
+    const T& right_top_y() const { return right_top().y(); }
+
+    static bool IsValid(const Position& left_bottom, const Position& right_top)
+    {
+        return IsValid(left_bottom.x(), left_bottom.y(), right_top.x(), right_top.y());
+    }
+
+    static bool IsValid(const T& left_bottom_x, const T& left_bottom_y, const T& right_top_x, const T& right_top_y)
+    {
+        return analysis::Range<T>::IsValid(left_bottom_x, right_top_x)
+                && analysis::Range<T>::IsValid(left_bottom_y, right_top_y);
+    }
+
+private:
+    void CheckValidity() const
+    {
+        if(!IsValid(_left_bottom, _right_top))
+            throw analysis::exception("Invalid box [%1% %2%]") % _left_bottom % _right_top;
+    }
+
+private:
+    Position _left_bottom, _right_top;
+};
+
+template<typename T>
+std::ostream& operator<<(std::ostream& s, const Box<T>& b)
+{
+    s << b.left_bottom() << " " << b.right_top();
+    return s;
+}
+
+template<typename T>
+std::istream& operator>>(std::istream& s, Box<T>& b)
+{
+    typename Box<T>::Position left_bottom, right_top;
+    try {
+        s >> left_bottom >> right_top;
+    }catch(analysis::exception&) {
+        throw analysis::exception("Invalid box.");
+    }
+    b = Box<T>(left_bottom, right_top);
+    return s;
+}
+
+template<typename T>
+struct MarginBox {
+    MarginBox() : _left(0), _bottom(0), _right(0), _top(0) {}
+
+    MarginBox(const T& left, const T& bottom, const T& right, const T& top)
+        : _left(left), _bottom(bottom), _right(right), _top(top)
+    {
+        CheckValidity();
+    }
+
+    const T& left() const { return _left; }
+    const T& bottom() const { return _bottom; }
+    const T& right() const { return _right; }
+    const T& top() const { return _top; }
+
+    static bool IsValid(const T& left, const T& bottom, const T& right, const T& top)
+    {
+        return IsValidMarginValue(left) && IsValidMarginValue(bottom)
+                && IsValidMarginValue(right) && IsValidMarginValue(top);
+    }
+
+    static bool IsValidMarginValue(const T& v) { return v >= 0 && v <= 1; }
+
+private:
+    void CheckValidity() const
+    {
+        if(!IsValid(_left, _bottom, _right, _top))
+            throw analysis::exception("Invalid margin box: (left, bottom, right, top) = (%1%, %2%, %3%, %4%).")
+                % _left % _bottom % _right % _top;
+    }
+
+private:
+    T _left, _bottom, _right, _top;
+};
+
+template<typename T>
+std::ostream& operator<<(std::ostream& s, const MarginBox<T>& b)
+{
+    s << boost::format("%1% %2% %3% %4%") % b.left() % b.bottom() % b.right() % b.top();
+    return s;
+}
+
+template<typename T>
+std::istream& operator>>(std::istream& s, MarginBox<T>& b)
+{
+    T left, bottom, right, top;
+    s >> left >> bottom >> right >> top;
+    if(s.fail())
+        throw analysis::exception("Invalid margin box.");
+    b = MarginBox<T>(left, bottom, right, top);
+    return s;
+}
+
+namespace detail {
+
+class ReferenceColorCollection {
+public:
+    using ColorNameMap = analysis::EnumNameMap<EColor>;
+    using ColorRelativeRangeMap = std::unordered_map<EColor, analysis::RelativeRange<int>, ColorNameMap::EnumHash>;
+    using ColorRangeMap = std::unordered_map<EColor, analysis::Range<int>, ColorNameMap::EnumHash>;
+
+    static const ColorNameMap& GetReferenceColorNames()
+    {
+        static const ColorNameMap names = ColorNameMap("EColor", {
+            { kWhite, "kWhite" }, { kBlack, "kBlack" }, { kGray, "kGray" }, { kRed, "kRed" }, { kGreen, "kGreen" },
+            { kBlue, "kBlue" }, { kYellow, "kYellow" }, { kMagenta, "kMagenta" }, { kCyan, "kCyan" },
+            { kOrange, "kOrange" }, { kSpring, "kSpring" }, { kTeal, "kTeal" }, { kAzure, "kAzure" },
+            { kViolet, "kViolet" }, { kPink, "kPink" }
+        });
+        return names;
+    }
+
+    static const ColorRelativeRangeMap& GetReferenceColorRelativeRanges()
+    {
+        static const ColorRelativeRangeMap ranges = {
+            { kWhite, { 0, 0 } }, { kBlack, { 0, 0 } }, { kGray, { 0, 3 } }, { kRed, { -10, 4 } },
+            { kGreen, { -10, 4 } }, { kBlue, { -10, 4 } }, { kYellow, { -10, 4 } }, { kMagenta, { -10, 4 } },
+            { kCyan, { -10, 4 } }, { kOrange, { -9, 10 } }, { kSpring, { -9, 10 } }, { kTeal, { -9, 10 } },
+            { kAzure, { -9, 10 } }, { kViolet, { -9, 10 } }, { kPink, { -9, 10 } }
+        };
+        return ranges;
+    }
+
+    static const ColorRangeMap& GetReferenceColorRanges()
+    {
+        static ColorRangeMap ranges;
+        if(!ranges.size()) {
+            for(const auto& rel_range : GetReferenceColorRelativeRanges())
+                ranges[rel_range.first] = rel_range.second.ToAbsoluteRange(static_cast<int>(rel_range.first));
+        }
+        return ranges;
+    }
+
+    static bool FindReferenceColor(int color_id, EColor& e_color, int& shift)
+    {
+        for(const auto& range : GetReferenceColorRanges()) {
+            if(range.second.Contains(color_id)) {
+                e_color = range.first;
+                shift = color_id - static_cast<int>(range.first);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static bool IsReferenceColor(int color_id)
+    {
+        EColor e_color;
+        int shift;
+        return FindReferenceColor(color_id, e_color, shift);
+    }
+
+    static int ToColorId(EColor e_color, int shift)
+    {
+        return static_cast<int>(e_color) + shift;
+    }
+
+    static std::string ToString(EColor e_color, int shift)
+    {
+        std::ostringstream ss;
+        ss << GetReferenceColorNames().EnumToString(e_color);
+        if(shift > 0)
+            ss << "+" << shift;
+        else if(shift < 0)
+            ss << shift;
+        return ss.str();
+    }
+
+    static std::string ToString(int color_id)
+    {
+        EColor e_color;
+        int shift;
+        if(!FindReferenceColor(color_id, e_color, shift))
+            throw analysis::exception("Unable to find a reference color for the color with id = %1%.") % color_id;
+        return ToString(e_color, shift);
+    }
+
+    static bool TryParse(const std::string& str, EColor& e_color, int& shift)
+    {
+        if(GetReferenceColorNames().TryParse(str, e_color)) {
+            shift = 0;
+            return true;
+        }
+        std::vector<std::string> sub_str;
+        boost::split(sub_str, str, boost::is_any_of("+-"), boost::token_compress_on);
+        if(sub_str.size() != 2 || !GetReferenceColorNames().TryParse(sub_str.at(0), e_color))
+            return false;
+        std::istringstream ss(sub_str.at(1));
+        ss >> shift;
+        int sign = std::find(str.begin(), str.end(), '-') == str.end() ? 1 : -1;
+        shift *= sign;
+        return !ss.fail();
+    }
+};
+
+} // namespace detail
+
+class Color {
+public:
+    Color() { RetrieveTColor(kBlack); }
+    explicit Color(int color_id) { RetrieveTColor(color_id); }
+    explicit Color(const std::string& hex_color)
+    {
+        static const boost::regex hex_color_pattern("^#(?:[0-9a-fA-F]{2}){3}$");
+        if(!boost::regex_match(hex_color, hex_color_pattern))
+            throw analysis::exception("Invalid color '%1%'.") % hex_color;
+        const int color_id = TColor::GetColor(hex_color.c_str());
+        RetrieveTColor(color_id);
+    }
+
+    bool IsSimple() const { return detail::ReferenceColorCollection::IsReferenceColor(GetColorId()); }
+    int GetColorId() const { return GetTColor().GetNumber(); }
+    const TColor& GetTColor() const { return *t_color; }
+
+    std::string ToString() const
+    {
+        if(IsSimple())
+            return detail::ReferenceColorCollection::ToString(GetColorId());
+        return GetTColor().AsHexString();
+    }
+
+private:
+    static void CheckComponent(const std::string& name, int value)
+    {
+        static const analysis::Range<int> color_range(0, 255);
+        if(!color_range.Contains(value))
+            throw analysis::exception("Invalid color %1% component value = %2%") % name % value;
+    }
+
+    void RetrieveTColor(int color_id)
+    {
+        t_color = gROOT->GetColor(color_id);
+        if(!t_color)
+            throw analysis::exception("Color with id %1% is not defined.") % color_id;
+    }
+
+private:
+    const TColor* t_color;
+};
+
+std::ostream& operator<<(std::ostream& s, const Color& c)
+{
+    s << c.ToString();
+    return s;
+}
+
+std::istream& operator>>(std::istream& s, Color& c)
+{
+
+    std::string name;
+    s >> name;
+    EColor e_color;
+    int shift;
+    if(detail::ReferenceColorCollection::TryParse(name, e_color, shift)) {
+        c = Color(detail::ReferenceColorCollection::ToColorId(e_color, shift));
+    } else
+        c = Color(name);
+    return s;
+}
+
+class Font {
+public:
+    using Integer = short;
+
+    Font() : _number(4), _precision(2) {}
+    explicit Font(Integer font_code)
+    {
+        ParseFontCode(font_code, _number, _precision);
+        CheckValidity();
+    }
+    Font(Integer font_number, Integer precision)
+        : _number(font_number), _precision(precision)
+    {
+        CheckValidity();
+    }
+
+    Integer code() const { return MakeFontCode(_number, _precision); }
+    Integer number() const { return _number; }
+    Integer precision() const { return _precision; }
+
+    static Integer MakeFontCode(Integer font_number, Integer precision) { return font_number * 10 + precision; }
+    static void ParseFontCode(Integer font_code, Integer& font_number, Integer& precision)
+    {
+        font_number = font_code / 10;
+        precision = font_code % 10;
+    }
+
+    static bool IsValid(Integer font_number, Integer precision)
+    {
+        static const analysis::Range<Integer> font_number_range(1, 15);
+        static const analysis::Range<Integer> precision_range(0, 3);
+        return font_number_range.Contains(font_number) && precision_range.Contains(precision);
+    }
+
+    static bool IsValid(Integer font_code)
+    {
+        Integer font_number, precision;
+        ParseFontCode(font_code, font_number, precision);
+        return IsValid(font_number, precision);
+    }
+
+private:
+    void CheckValidity() const
+    {
+        if(!IsValid(number(), precision()))
+            throw analysis::exception("Invalid font code = %1%.") % code();
+    }
+
+private:
+    Integer _number, _precision;
+};
+
+std::ostream& operator<<(std::ostream& s, const Font& f)
+{
+    s << f.code();
+    return s;
+}
+
+std::istream& operator>>(std::istream& s, Font& f)
+{
+    Font::Integer font_code;
+    s >> font_code;
+    f = Font(font_code);
+    return s;
+}
+
+enum class TextAlign { LeftBottom = kHAlignLeft + kVAlignBottom, LeftCenter = kHAlignLeft + kVAlignCenter,
+                       LeftTop = kHAlignLeft + kVAlignTop, CenterBottom = kHAlignCenter + kVAlignBottom,
+                       Center = kHAlignCenter + kVAlignCenter, CenterTop = kHAlignCenter + kVAlignTop,
+                       RightBottom = kHAlignRight + kVAlignBottom, RightCenter = kHAlignRight + kVAlignCenter,
+                       RightTop = kHAlignRight + kVAlignTop };
+ENUM_NAMES(TextAlign) = {
+    { TextAlign::LeftBottom, "left_bottom" },
+    { TextAlign::LeftCenter, "left_center" },
+    { TextAlign::LeftTop, "left_top" },
+    { TextAlign::CenterBottom, "center_bottom" },
+    { TextAlign::Center, "center" },
+    { TextAlign::CenterTop, "center_top" },
+    { TextAlign::RightBottom, "right_bottom" },
+    { TextAlign::RightCenter, "right_center" },
+    { TextAlign::RightTop, "right_top" }
+};
+
+} // namespace root_ext

--- a/Core/interface/RootExt.h
+++ b/Core/interface/RootExt.h
@@ -1,0 +1,171 @@
+/*! Common CERN ROOT extensions.
+This file is part of https://github.com/hh-italian-group/AnalysisTools. */
+
+#pragma once
+
+#include <memory>
+
+#include <TLorentzVector.h>
+#include <TMatrixD.h>
+#include <TFile.h>
+#include <Compression.h>
+
+#include "exception.h"
+
+namespace root_ext {
+
+inline std::shared_ptr<TFile> CreateRootFile(const std::string& file_name)
+{
+    std::shared_ptr<TFile> file(TFile::Open(file_name.c_str(), "RECREATE", "", ROOT::kZLIB * 100 + 9));
+    if(file->IsZombie())
+        throw analysis::exception("File '%1%' not created.") % file_name;
+    return file;
+}
+
+inline std::shared_ptr<TFile> OpenRootFile(const std::string& file_name)
+{
+    std::shared_ptr<TFile> file(TFile::Open(file_name.c_str(), "READ"));
+    if(!file || file->IsZombie())
+        throw analysis::exception("File '%1%' not opened.") % file_name;
+    return file;
+}
+
+template<typename Object>
+void WriteObject(const Object& object)
+{
+    TDirectory* dir = object.GetDirectory();
+    if(!dir)
+        throw analysis::exception("Can't write object to nullptr.");
+    dir->WriteTObject(&object, object.GetName(), "Overwrite");
+}
+
+template<typename Object>
+void WriteObject(const Object& object, TDirectory* dir, const std::string& name = "")
+{
+    if(!dir)
+        throw analysis::exception("Can't write object to nullptr.");
+    const std::string name_to_write = name.size() ? name : object.GetName();
+    dir->WriteTObject(&object, name_to_write.c_str(), "Overwrite");
+}
+
+template<typename Object>
+Object* ReadObject(TFile& file, const std::string& name)
+{
+    if(!name.size())
+        throw analysis::exception("Can't read nameless object.");
+    TObject* root_object = file.Get(name.c_str());
+    if(!root_object)
+        throw analysis::exception("Object '%1%' not found in '%2%'.") % name % file.GetName();
+    Object* object = dynamic_cast<Object*>(root_object);
+    if(!object)
+        throw analysis::exception("Wrong object type '%1%' for object '%2%' in '%3%'.") % typeid(Object).name()
+            % name % file.GetName();
+    return object;
+}
+
+template<typename Object>
+Object* TryReadObject(TFile& file, const std::string& name)
+{
+    try {
+        return ReadObject<Object>(file, name);
+    } catch(analysis::exception&) {}
+    return nullptr;
+}
+
+template<typename Object>
+Object* CloneObject(const Object& original_object, const std::string& new_name = "")
+{
+    const std::string new_object_name = new_name.size() ? new_name : original_object.GetName();
+    Object* new_object = dynamic_cast<Object*>(original_object.Clone(new_object_name.c_str()));
+    if(!new_object)
+        throw analysis::exception("Type error while cloning object '%1%'.") % original_object.GetName();
+    return new_object;
+}
+
+template<typename Object>
+Object* CloneObject(const Object& original_object, const std::string& new_name, bool detach_from_file)
+{
+    Object* new_object = CloneObject(original_object, new_name);
+    if(detach_from_file)
+        new_object->SetDirectory(nullptr);
+    return new_object;
+}
+
+template<typename Object>
+Object* ReadCloneObject(TFile& file, const std::string& original_name, const std::string& new_name = "",
+                        bool detach_from_file = false)
+{
+    Object* original_object = ReadObject<Object>(file, original_name);
+    return CloneObject(*original_object, new_name, detach_from_file);
+}
+
+} // namespace root_ext
+
+
+inline std::ostream& operator<<(std::ostream& s, const TVector3& v) {
+    s << "(" << v.x() << ", " << v.y() << ", " << v.z() << ")";
+    return s;
+}
+
+inline std::ostream& operator<<(std::ostream& s, const TLorentzVector& v) {
+    s << "(pt=" << v.Pt() << ", eta=" << v.Eta() << ", phi=" << v.Phi() << ", E=" << v.E() << ", m=" << v.M() << ")";
+    return s;
+}
+
+// Based on TMatrixD::Print code.
+inline std::ostream& operator<<(std::ostream& s, const TMatrixD& matrix)
+{
+    if (!matrix.IsValid()) {
+        s << "Matrix is invalid";
+        return s;
+    }
+
+    //build format
+    const char *format = "%11.4g ";
+    char topbar[100];
+    snprintf(topbar,100,format,123.456789);
+    Int_t nch = strlen(topbar)+1;
+    if (nch > 18) nch = 18;
+    char ftopbar[20];
+    for (Int_t i = 0; i < nch; i++) ftopbar[i] = ' ';
+    Int_t nk = 1 + Int_t(std::log10(matrix.GetNcols()));
+    snprintf(ftopbar+nch/2,20-nch/2,"%s%dd","%",nk);
+    Int_t nch2 = strlen(ftopbar);
+    for (Int_t i = nch2; i < nch; i++) ftopbar[i] = ' ';
+    ftopbar[nch] = '|';
+    ftopbar[nch+1] = 0;
+
+    s << matrix.GetNrows() << "x" << matrix.GetNcols() << " matrix";
+
+    Int_t cols_per_sheet = 5;
+    if (nch <= 8) cols_per_sheet =10;
+    const Int_t ncols  = matrix.GetNcols();
+    const Int_t nrows  = matrix.GetNrows();
+    const Int_t collwb = matrix.GetColLwb();
+    const Int_t rowlwb = matrix.GetRowLwb();
+    nk = 5+nch*std::min(cols_per_sheet, matrix.GetNcols());
+    for (Int_t i = 0; i < nk; i++)
+        topbar[i] = '-';
+    topbar[nk] = 0;
+    for (Int_t sheet_counter = 1; sheet_counter <= ncols; sheet_counter += cols_per_sheet) {
+        s << "\n     |";
+        for (Int_t j = sheet_counter; j < sheet_counter+cols_per_sheet && j <= ncols; j++) {
+            char ftopbar_out[100];
+            snprintf(ftopbar_out, 100, ftopbar, j+collwb-1);
+            s << ftopbar_out;
+        }
+        s << "\n" << topbar << "\n";
+        if (matrix.GetNoElements() <= 0) continue;
+        for (Int_t i = 1; i <= nrows; i++) {
+            char row_out[100];
+            snprintf(row_out, 100, "%4d |",i+rowlwb-1);
+            s << row_out;
+            for (Int_t j = sheet_counter; j < sheet_counter+cols_per_sheet && j <= ncols; j++) {
+                snprintf(row_out, 100, format, matrix(i+rowlwb-1,j+collwb-1));
+                s << row_out;
+            }
+            s << "\n";
+        }
+    }
+    return s;
+}

--- a/Core/interface/TextIO.h
+++ b/Core/interface/TextIO.h
@@ -1,0 +1,128 @@
+/*! Definition of primitives for a text based input/output.
+This file is part of https://github.com/hh-italian-group/AnalysisTools. */
+
+#pragma once
+
+#include "exception.h"
+#include <unordered_set>
+#include <boost/algorithm/string.hpp>
+
+namespace analysis {
+
+template<typename T, typename CharT = char>
+std::basic_string<CharT> ToString(const T& t)
+{
+    std::basic_ostringstream<CharT> ss;
+    ss << t;
+    return ss.str();
+}
+
+template<typename T, typename CharT>
+bool TryParse(const std::basic_string<CharT>& str, T& t)
+{
+    try {
+        std::basic_istringstream<CharT> ss(str);
+        ss >> t;
+        return !ss.fail();
+    } catch(std::exception&) {}
+    return false;
+}
+
+template<typename T, typename CharT>
+T Parse(const std::basic_string<CharT>& str)
+{
+    T t;
+    std::basic_istringstream<CharT> ss(str);
+    ss >> t;
+    if(ss.fail())
+        throw exception("Parse of string '%1%' to %2% is failed.") % str % typeid(T).name();
+    return t;
+}
+
+template<typename T>
+std::vector<std::string> ToStringVector(const std::vector<T>& v)
+{
+    std::vector<std::string> result;
+    std::transform(v.begin(), v.end(), std::back_inserter(result),
+                   [](const T& x) { std::ostringstream ss; ss << x; return ss.str(); });
+    return result;
+}
+
+template<typename Collection>
+static std::string CollectionToString(const Collection& col, const std::string& separator = ", ")
+{
+    std::ostringstream ss;
+    auto iter = col.begin();
+    if(iter != col.end())
+        ss << *iter++;
+    for(; iter != col.end(); ++iter)
+        ss << separator << *iter;
+    return ss.str();
+}
+
+inline std::vector<std::string> SplitValueList(std::string values_str, bool allow_duplicates = true,
+                                               const std::string& separators = " \t",
+                                               bool enable_token_compress = true)
+{
+    std::vector<std::string> result;
+    if(enable_token_compress)
+        boost::trim_if(values_str, boost::is_any_of(separators));
+    const auto token_compress = enable_token_compress ? boost::algorithm::token_compress_on
+                                                      : boost::algorithm::token_compress_off;
+    boost::split(result, values_str, boost::is_any_of(separators), token_compress);
+    if(!allow_duplicates) {
+        std::unordered_set<std::string> set_result;
+        for(const std::string& value : result) {
+            if(set_result.count(value))
+                throw exception("Value '%1%' listed more than once in the value list '%2%'.") % value % values_str;
+            set_result.insert(value);
+        }
+    }
+    return result;
+}
+
+inline std::vector<std::string> ReadValueList(std::istream& stream, size_t number_of_items,
+                                              bool allow_duplicates = true,
+                                              const std::string& separators = " \t",
+                                              bool enable_token_compress = true)
+{
+    const auto stream_exceptions = stream.exceptions();
+    stream.exceptions(std::istream::goodbit);
+    try {
+        std::vector<std::string> result;
+        std::unordered_set<std::string> set_result;
+        const auto predicate = boost::is_any_of(separators);
+        size_t n = 0;
+        for(; n < number_of_items; ++n) {
+            std::string value;
+            while(true) {
+                const auto c = stream.get();
+                if(!stream.good()) {
+                    if(stream.eof()) break;
+                    throw exception("Failed to read values from stream.");
+                }
+                if(predicate(c)) {
+                    if(!value.size() && enable_token_compress) continue;
+                    break;
+                }
+                value.push_back(c);
+            }
+            if(!allow_duplicates && set_result.count(value))
+                throw exception("Value '%1%' listed more than once in the input stream.") % value;
+            result.push_back(value);
+            set_result.insert(value);
+        }
+        if(n != number_of_items)
+            throw exception("Expected %1% items, while read only %2%.") % number_of_items % n;
+
+        stream.clear();
+        stream.exceptions(stream_exceptions);
+        return result;
+    } catch(exception&) {
+        stream.clear();
+        stream.exceptions(stream_exceptions);
+        throw;
+    }
+}
+
+} // namespace analysis

--- a/Core/interface/exception.h
+++ b/Core/interface/exception.h
@@ -1,12 +1,12 @@
-/*! Definition of the base exception class for the hh_analysis namespace.
-This file is part of https://github.com/cms-hh/StatAnalysis. */
+/*! Definition of the base exception class for the analysis namespace.
+This file is part of https://github.com/hh-italian-group/AnalysisTools. */
 
 #pragma once
 
 #include <boost/format.hpp>
 #include <sstream>
 
-namespace hh_analysis {
+namespace analysis {
 
 class exception : public std::exception {
 public:
@@ -27,4 +27,4 @@ private:
     boost::format f_msg;
 };
 
-} // hh_analysis
+} // analysis

--- a/README.md
+++ b/README.md
@@ -6,25 +6,19 @@ This package is based on the tools, code and interfaces provided by [CombineHarv
 
 ## How to install
 
-The installation steps follows guidelines from CombineHarvester (http://cms-analysis.github.io/CombineHarvester/) and CMS combine (https://twiki.cern.ch/twiki/bin/viewauth/CMS/SWGuideHiggsAnalysisCombinedLimit/) documentations:
+The installation steps follows guidelines from CombineHarvester (http://cms-analysis.github.io/CombineHarvester/) and CMS combine (https://twiki.cern.ch/twiki/bin/viewauth/CMS/SWGuideHiggsAnalysisCombinedLimit/) documentations.
 
+The recommended way to install HHStatAnalysis framework is by using install.sh script located in https://github.com/cms-hh/HHStatAnalysis/blob/master/install.sh
 ```shell
-export SCRAM_ARCH=slc6_amd64_gcc491
-cmsrel CMSSW_7_4_7
-cd CMSSW_7_4_7/src
-cmsenv
-git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
-cd HiggsAnalysis/CombinedLimit
-git checkout v6.2.1
-cd ../..
-git clone https://github.com/cms-analysis/CombineHarvester.git CombineHarvester
-cd CombineHarvester
-git checkout CombineHarvester-v16.2.1
-cd ..
-git clone -o upstream git@github.com:cms-hh/HHStatAnalysis.git HHStatAnalysis
-git clone -o upstream git@github.com:cms-hh/Resources.git HHStatAnalysis/Resources
-scram b -j4
+curl -s https://raw.githubusercontent.com/cms-hh/HHStatAnalysis/master/install.sh | bash -s [MODE] [N_JOBS] [CMSSW_RELEASE]
 ```
+where MODE is the installation mode: *full* for the full installation, and *plotting* to install only the plotting-related code (default *full*); N_JOBS is the number of jobs to run simultaneous during the compilation (default 8), CMSSW_RELEASE is the CMSSW release (default CMSSW_7_4_7).
+
+Example:
+```shell
+curl -s https://raw.githubusercontent.com/cms-hh/HHStatAnalysis/master/install.sh | bash -s
+```
+
 
 ## How to run
 
@@ -33,32 +27,69 @@ For details about how to run tools provided by CombineHarvester (e.g. combineToo
 
 ### How to run limits for a single channel
 
-- Create datacards:
+- Create a configuration file (see the next section).
+- Run all limit extraction steps up to plotting using run_hh_limits.py script:
 ```shell
-create_hh_datacards --unc-model UNC_MODEL_NAME --shapes-path SHAPES_PATH --output-path OUTPUT_PATH
+run_hh_limits.py --cfg CFG_FILE --model-desc DESC --output OUTPUT_PATH [--parallel N_JOBS] shape_file [shape_file] ...
 ```
-where *UNC_MODEL_NAME* is the name of the module that implements an uncertainty model for the given channel (e.g. "bbtautau_resonant"), *SHAPES_PATH* - path to the ROOT files with the signal, data and background shapes, *OUTPUT_PATH* - path where to store datacards.
+where CFG_FILE is the configuration file; DESC is the name of a model descriptor entry in the config; OUTPUT_PATH is the path where the limit files should be stored; N_JOSB is the number of parallel jobs; shape_file - file (or files) with the input shapes.
 
-- Create workspace:
+Examples:
 ```shell
-cd OUTPUT_PATH
-combineTool.py -M T2W -i */* -o workspace.root --parallel 8
-```
-
-- Run limits:
-```shell
-combineTool.py -M Asymptotic -d */*/workspace.root --there -n .limit --parallel 8
+# bbtautau resonant model independent limits
+run_hh_limits.py --cfg HHStatAnalysis/Resources/LimitSetups/ttbb_resonant.cfg --model-desc ttbb_res --output output/limits shapes/LLR_shapes.root
+# bbtautau resonant limits for hMSSM model
+run_hh_limits.py --cfg HHStatAnalysis/Resources/LimitSetups/ttbb_resonant.cfg --model-desc ttbb_res_hMSSM --output output/limits_hMSSM shapes/LLR_shapes.root
 ```
 
-- Collect all outputs:
-```shell
-combineTool.py -M CollectLimits */*/*.limit.* --use-dirs -o limits.json
-```
+## Configuration description
 
-- Produce plots:
-```shell
-plotLimits.py JSON_FILE --auto-style
+### Overview
+
+Used text-based configuration format originally implemented and used within hh-italian-group framework (https://github.com/hh-italian-group/AnalysisTools/).
+
+Configuration is represented as a list of configuration entries. Each configuration entry starts with entry header and ends with an empty line. Entry header has a following format:
+
 ```
+[TYPE entry_name]
+```
+*OR*
+```
+[TYPE entry_name : reference_entry_name]
+```
+where *TYPE* is entry type and can be omitted for the default entry type, *entry_name* is the entry name that should be unique for a given TYPE, *reference_entry_name* the name of a reference entry of the same type that is used to initialize the entry.
+
+Each configuration entry is a set of properties. Each property is represented by one line in the configuration file and has a following format:
+```
+property_name: property_value
+```
+Each entry type defines its own set of properties, related parsing rules and allowed property multiplicity.
+
+Other remarks:
+- spaces in entry and property names are not allowed;
+- lines that starts with "#" are considered as commentary and are ignored by the configuration parser.
+
+#### StatModel entry properties
+Entry type name is *MODEL*. It is the default entry type.
+
+Name                    | Description | Value format | Multiplicity
+------------------------|-------------|--------------|-------------
+stat_model              | name of the stat model | stat_model_name | &#8804; 1
+channels                | list of channels | ch1 ch2 ... | &#8804; 1
+categories              | list of categories | cat1 cat2 ... | &#8804; 1
+signal_process          | name of the signal process | process_name | &#8804; 1
+model_signal_process    | name of the signal process in the format expected for the model dependent interpretation | process_name | &#8804; 1
+signal_point_prefix     | prefix before the signal point inside the names of the input shape histograms (e.g. 'M') | prefix | &#8804; 1
+signal_points           | list of the signal point (e.g. resonance masses) | p1 p2 ... | &#8804; 1
+limit_type              | limit type | model_independent &#124; MSSM | &#8804; 1
+th_model_file           | file with the theoretical grid for the model dependent interpretation | file_path | &#8804; 1
+blind                   | whatever the final limits should be blind or not | true &#124; false | &#8804; 1
+morph                   | whatever the morphing should be applied for input signal shapes (required for model dependent interpretation) | true &#124; false | &#8804; 1
+combine_channels        | whatever to combine channels or not | true &#124; false | &#8804; 1
+per_channel_limits      | whatever per-channel limits should be produced or not | true &#124; false | &#8804; 1
+grid_x                  | range and step definition for the x-axis of the grid points that will be used for model dependent interpretation | min:max:step | &#8804; 1
+grid_y                  | range and step definition for the y-axis of the grid points that will be used for model dependent interpretation | min:max:step | &#8804; 1
+custom_param            | custom parameter that can be used by the stat model implementation | name value | &#8805; 0
 
 ## How to add new statistical model
 

--- a/StatModels/BuildFile.xml
+++ b/StatModels/BuildFile.xml
@@ -1,2 +1,5 @@
 <export><lib name="1"/></export>
+<use name="python"/>
+<use name="boost_python"/>
 <use name="CombineHarvester/CombineTools"/>
+<use name="CombineHarvester/CombinePdfs"/>

--- a/StatModels/bin/BuildFile.xml
+++ b/StatModels/bin/BuildFile.xml
@@ -1,2 +1,3 @@
 <bin file="create_hh_datacards.cpp" name="create_hh_datacards"></bin>
+<bin file="simple_hh_interpret.cpp" name="simple_hh_interpret"></bin>
 <use name="HHStatAnalysis/StatModels"/>

--- a/StatModels/bin/create_hh_datacards.cpp
+++ b/StatModels/bin/create_hh_datacards.cpp
@@ -1,16 +1,18 @@
 /*! Tool to create HH datacards.
-This file is part of https://github.com/cms-hh/StatAnalysis. */
+This file is part of https://github.com/cms-hh/HHStatAnalysis. */
 
 #include "HHStatAnalysis/Core/interface/program_main.h"
 #include "HHStatAnalysis/Core/interface/exception.h"
 #include "HHStatAnalysis/StatModels/interface/StatModelFactory.h"
+#include "HHStatAnalysis/StatModels/interface/Config.h"
 
 namespace {
 
 struct Arguments {
-    run::Argument<std::string> uncModelName{"stat-model", "name of the stat model to run"};
-    run::Argument<std::string> shapesPathName{"shapes-path", "path where shape files are located"};
-    run::Argument<std::string> outputPathName{"output-path", "path where to store created datacards"};
+    run::Argument<std::string> cfg{"cfg", "configuration file"};
+    run::Argument<std::string> model_desc{"model-desc", "name of the stat model descriptor in the config"};
+    run::Argument<std::string> shapes{"shapes", "file with input shapes"};
+    run::Argument<std::string> output_path{"output", "path where to store created datacards"};
 };
 
 } // anonymous namespace
@@ -23,12 +25,12 @@ public:
 
     void Run()
     {
-        auto model = stat_models::StatModelFactory::Make(args.uncModelName());
+        const StatModelDescriptor model_desc = LoadDescriptor(args.cfg(), args.model_desc());
+        auto model = stat_models::StatModelFactory::Make(model_desc);
         std::cout << boost::format("Creating datacards for %1% unc model using %2% shapes...")
-                     % args.uncModelName() % args.shapesPathName() << std::endl;
-        model->CreateDatacards(args.shapesPathName(), args.outputPathName());
-        std::cout << boost::format("Datacards are successfully created into '%1%'.") % args.outputPathName()
-                  << std::endl;
+                     % model_desc.stat_model % args.shapes() << std::endl;
+        model->CreateDatacards(args.shapes(), args.output_path());
+        std::cout << boost::format("Datacards are successfully created into '%1%'.") % args.output_path() << std::endl;
     }
 
 private:

--- a/StatModels/bin/run_hh_limits.sh
+++ b/StatModels/bin/run_hh_limits.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+if [ $# -ne 3 ] ; then
+    echo "Usage: stat_model shapes_path output_path"
+    exit 1
+fi
+
+STAT_MODEL="$1"
+SHAPES_PATH="$2"
+OUTPUT_PATH="$3"
+N_PARALLEL=4
+JSON_NAME="limits"
+JSON_FILE="${JSON_NAME}.json"
+JSON_PATTERN="${JSON_NAME}_*.json"
+
+create_hh_datacards --stat-model "$STAT_MODEL" --shapes-path "$SHAPES_PATH" --output-path "$OUTPUT_PATH"
+RESULT=$?
+if [ $RESULT -ne 0 ] ; then
+    echo "Error occurred while creating hh datacards."
+    exit 1
+fi
+
+cd "$OUTPUT_PATH"
+combineTool.py -M T2W -i */* -o workspace.root --parallel $N_PARALLEL
+combineTool.py -M Asymptotic -d */*/workspace.root --there -n .limit --parallel $N_PARALLEL
+combineTool.py -M CollectLimits */*/*.limit.* --use-dirs -o "$JSON_FILE"
+
+
+INPUT_FILES=( $(find . -maxdepth 1 -type f -name "$JSON_PATTERN" | sort) )
+
+for input_file in "${INPUT_FILES[@]}" ; do
+    plotLimits.py "$input_file" --auto-style --y-title "95% CL limit on #sigma (pb)" --logy
+done

--- a/StatModels/bin/simple_hh_interpret.cpp
+++ b/StatModels/bin/simple_hh_interpret.cpp
@@ -1,0 +1,542 @@
+/*! Tool that provides a simple division-based HH model-dependent interpretation.
+This file is part of https://github.com/cms-hh/HHStatAnalysis. */
+
+#include <boost/regex.hpp>
+#include <boost/filesystem.hpp>
+#include <TFile.h>
+#include <TTree.h>
+#include <TH2.h>
+#include <TGraph2D.h>
+#include <Math/Interpolator.h>
+#include "HHStatAnalysis/Core/interface/program_main.h"
+#include "HHStatAnalysis/Core/interface/exception.h"
+#include "HHStatAnalysis/Core/interface/EnumNameMap.h"
+#include "HHStatAnalysis/Core/interface/NumericPrimitives.h"
+#include "HHStatAnalysis/Core/interface/RootExt.h"
+
+namespace hh_analysis {
+using namespace analysis;
+using StrVec = std::vector<std::string>;
+using InterpolatorPtr = std::shared_ptr<ROOT::Math::Interpolator> ;
+
+const std::vector<double> all_limit_quantiles = { -1., 0.025, 0.16, 0.5, 0.84, 0.975 };
+const StrVec all_limit_quantile_names = { "obs", "exp-2", "exp-1", "exp0", "exp+1", "exp+2" };
+
+size_t GetQuantileId(double quantile)
+{
+    static const double delta = 0.01;
+    for(size_t n = 0; n < all_limit_quantiles.size(); ++n) {
+        if(std::abs(all_limit_quantiles[n] - quantile) < delta)
+            return n;
+    }
+    throw exception("Unknown quantile = %1%") % quantile;
+}
+
+double GetHiggsMass(const std::string& file_name)
+{
+    static const StrVec mass_patterns = { "mR([0-9]*)", "mH([0-9]*)" };
+    for(const auto& pattern_str : mass_patterns) {
+        const boost::regex pattern(pattern_str);
+        boost::smatch mass_match;
+        if(boost::regex_search(file_name, mass_match, pattern)) {
+            std::istringstream ss_mass(mass_match[1]);
+            double mass;
+            ss_mass >> mass;
+            return mass;
+        }
+    }
+    throw exception("Bad file name %1%") % file_name;
+}
+
+std::set<std::pair<double, std::string>> GetOrderedFileList(const std::string& input_dir_name,
+                                                            const std::string& pattern_str)
+{
+    using namespace boost::filesystem;
+    std::set<std::pair<double, std::string>> files;
+    const boost::regex pattern(pattern_str);
+    const path input_dir(input_dir_name);
+    const directory_iterator end_iter;
+    for(directory_iterator file_iter(input_dir); file_iter != end_iter; ++file_iter) {
+        const auto& name = file_iter->path().string();
+        if(is_regular_file(file_iter->path()) && boost::regex_match(name, pattern))
+            files.insert(std::make_pair(GetHiggsMass(name), name));
+    }
+    return files;
+}
+
+enum class Particle { H, A, h };
+ENUM_NAMES(Particle) = {
+    { Particle::H, "H" }, { Particle::A, "A" }, { Particle::h, "h" }
+};
+
+enum class Process { gg_H, H_hh, h_gammagamma, h_bb, h_tautau };
+ENUM_NAMES(Process) = {
+    { Process::gg_H, "gg->H" }, { Process::H_hh, "H->hh" }, { Process::h_gammagamma, "h->gammagamma" },
+    { Process::h_bb, "h->bb" }, { Process::h_tautau, "h->tautau" }
+};
+
+enum class Units { pb, fb };
+ENUM_NAMES(Units) = {
+    { Units::pb, "pb" }, { Units::fb, "fb" }
+};
+
+enum class CompositProcess { ggH_hh_bbtautau, ggH_hh_bbgammagamma };
+ENUM_NAMES(CompositProcess) = {
+    { CompositProcess::ggH_hh_bbtautau, "ggH_hh_bbtautau" },
+    { CompositProcess::ggH_hh_bbgammagamma, "ggH_hh_bbgammagamma" },
+};
+
+ENUM_OSTREAM_OPERATORS()
+ENUM_ISTREAM_OPERATORS()
+
+double GetUnitsFactor(Units units)
+{
+    static const std::map<Units, double> units_factors = {
+        { Units::pb, 1. }, { Units::fb, 1e-3 }
+    };
+    if(!units_factors.count(units))
+        throw exception("Unknown units '%1%'") % units;
+    return units_factors.at(units);
+}
+
+class Model {
+public:
+    typedef std::vector<double> Point;
+    typedef std::map<Particle, double> ParticleParamMap;
+    typedef std::map<Process, double> ProcessParamMap;
+
+    struct PointDescriptor {
+        Point point;
+        ParticleParamMap masses;
+        ProcessParamMap cross_sections, branching_ratios;
+        const Model* model;
+
+        const std::string& GetParamName(size_t dim) const
+        {
+            if(!model)
+                throw exception("Model is not available.");
+            return model->GetParamName(dim);
+        }
+
+        std::string GetParamNameString() const
+        {
+            if(!model)
+                throw exception("Model is not available.");
+            return model->GetParamNameString();
+        }
+
+        std::string ToString() const { return Model::VectorToString(point); }
+
+        double GetMass(Particle particle) const
+        {
+            return GetValue(masses, particle, "mass");
+        }
+
+        double GetCrossSection(Process process) const
+        {
+            return GetValue(cross_sections, process, "cross section");
+        }
+
+        double GetBranchingRatio(Process process) const
+        {
+            return GetValue(branching_ratios, process, "branching ratio");
+        }
+
+        double GetProcessBR_CS(CompositProcess process) const
+        {
+            if(process == CompositProcess::ggH_hh_bbgammagamma) {
+                return 2.0 * GetCrossSection(Process::gg_H)
+                           * GetBranchingRatio(Process::H_hh)
+                           * GetBranchingRatio(Process::h_bb)
+                           * GetBranchingRatio(Process::h_gammagamma);
+            }
+            else if(process == CompositProcess::ggH_hh_bbtautau) {
+                return 2.0 * GetCrossSection(Process::gg_H)
+                           * GetBranchingRatio(Process::H_hh)
+                           * GetBranchingRatio(Process::h_bb)
+                           * GetBranchingRatio(Process::h_tautau);
+            }
+            throw exception("Unsupported process '%1%'.") % process;
+        }
+
+    private:
+        template<typename Map>
+        double GetValue(const Map& map, const typename Map::key_type& key, const std::string& param_name) const
+        {
+            if(!map.count(key))
+                throw exception("%1% %2% not found for the parameter phase space point %3% = %4%.")
+                            % key % param_name % GetParamNameString() % ToString();
+            return map.at(key);
+        }
+    };
+
+    typedef std::list<PointDescriptor> PointDescriptorCollection;
+
+    Model(const StrVec& _param_names)
+        : param_names(_param_names), param_names_str(VectorToString(_param_names)) {}
+
+    const PointDescriptorCollection& GetAvailablePoints() const { return points; }
+    size_t GetNumberOfDimensions() const { return param_names.size(); }
+
+    const std::string& GetParamName(size_t dim) const
+    {
+        if(!dim || dim > param_names.size())
+            throw exception("Model parameter phase space do not contain dimension %1%") % dim;
+        return param_names.at(dim - 1);
+    }
+
+    const std::string& GetParamNameString() const { return param_names_str; }
+
+    template<typename Vector>
+    static std::string VectorToString(const Vector& v)
+    {
+        return "(" + CollectionToString(v) + ")";
+    }
+
+protected:
+    PointDescriptorCollection points;
+
+private:
+    StrVec param_names;
+    std::string param_names_str;
+};
+
+class ModelReader {
+public:
+    virtual ~ModelReader() {}
+    virtual Model::PointDescriptorCollection CollectAvailablePoints() const = 0;
+    virtual std::shared_ptr<TH2F> GetReferenceHistogram() const = 0;
+};
+
+template<typename _Histogram>
+class ModelReader_Hist2D : public ModelReader {
+public:
+    typedef _Histogram Hist;
+    typedef std::shared_ptr<Hist> HistPtr;
+
+    ModelReader_Hist2D(const std::string& file_name, size_t _version)
+        : file(new TFile(file_name.c_str(), "READ")), version(_version)
+    {
+        static const std::map<Particle, std::vector<std::string>> Mass_dictionary {
+            { Particle::H, { "h_mH", "m_H", "mH" } },
+            { Particle::A, { "h_mA", "m_A", "mA" } },
+            { Particle::h, { "h_mh", "m_h", "mh" } }
+        };
+
+        static const std::map<Process, std::vector<std::string>> CS_dictionary {
+            { Process::gg_H, { "h_ggF_xsec_H", "xs_gg_H", "xs_ggH" } }
+        };
+
+        static const std::map<Process, std::vector<std::string>> BR_dictionary {
+            { Process::H_hh, { "h_brh0h0_H", "br_H_hh", "br_Hhh" } },
+            { Process::h_gammagamma, { "h_brgammagamma_h", "br_h_gamgam", "br_hgammagamma" } },
+            { Process::h_bb, { "h_brbb_h", "br_h_bb", "br_hbb" } },
+            { Process::h_tautau, { "h_brtautau_h", "br_h_tautau", "br_htautau" } }
+        };
+
+        ReadAllHistograms(Mass_dictionary, masses);
+        ReadAllHistograms(CS_dictionary, cross_sections);
+        ReadAllHistograms(BR_dictionary, branching_ratios);
+        if(!all_hists.size())
+            throw exception("No histograms is read.");
+        if(!CheckHistsCompatibility(all_hists))
+            throw exception("Not all model histograms have compatible binning");
+    }
+
+    virtual Model::PointDescriptorCollection CollectAvailablePoints() const override
+    {
+        Model::PointDescriptorCollection points;
+        const auto ref_hist = *all_hists.begin();
+        for(Int_t x_id = 1; x_id <= ref_hist->GetXaxis()->GetNbins(); ++x_id) {
+            const double x = ref_hist->GetXaxis()->GetBinCenter(x_id);
+            for(Int_t y_id = 1; y_id <= ref_hist->GetYaxis()->GetNbins(); ++y_id) {
+                const double y = ref_hist->GetYaxis()->GetBinCenter(y_id);
+                Model::PointDescriptor desc;
+                desc.point = Model::Point({x, y});
+                for(const auto& entry : masses)
+                    desc.masses[entry.first] = entry.second->GetBinContent(x_id, y_id);
+                for(const auto& entry : cross_sections)
+                    desc.cross_sections[entry.first] = entry.second->GetBinContent(x_id, y_id);
+                for(const auto& entry : branching_ratios)
+                    desc.branching_ratios[entry.first] = entry.second->GetBinContent(x_id, y_id);
+                points.push_back(desc);
+            }
+        }
+        return points;
+    }
+
+    virtual std::shared_ptr<TH2F> GetReferenceHistogram() const override
+    {
+        return *all_hists.begin();
+    }
+
+private:
+    HistPtr GetHist(const std::string& hist_name) const
+    {
+        HistPtr hist(dynamic_cast<Hist*>(file->Get(hist_name.c_str())));
+        if(!hist)
+            throw exception("Can't read histogram '%1%' from model file '%2%'.")
+                % hist_name % file->GetName();
+        return hist;
+    }
+
+    template<typename NameMap, typename OutputMap>
+    void ReadAllHistograms(const NameMap& dictionary, OutputMap& values)
+    {
+        for(const auto& entry : dictionary) {
+            const std::string& hist_name = entry.second.at(version);
+            if(!hist_name.size()) continue;
+            const auto hist = GetHist(hist_name);
+            values[entry.first] = hist;
+            all_hists.push_back(hist);
+        }
+    }
+
+    template<typename HistContainer>
+    static bool CheckHistsCompatibility(const HistContainer& hists)
+    {
+        if(!hists.size()) return true;
+        auto ref_iter = hists.begin();
+        for(auto hist_iter = std::next(ref_iter); hist_iter != hists.end(); ++hist_iter) {
+            if(!CheckAxisCompatibility(*(*ref_iter)->GetXaxis(), *(*hist_iter)->GetXaxis())
+                || !CheckAxisCompatibility(*(*ref_iter)->GetYaxis(), *(*hist_iter)->GetYaxis()))
+                return false;
+        }
+        return true;
+    }
+
+    static bool CheckAxisCompatibility(const TAxis& a, const TAxis& b)
+    {
+        static const double delta_max = 0.001;
+        static const double rel_delta_max = 0.01;
+
+        if(a.GetNbins() != b.GetNbins()) return false;
+        for(Int_t n = 1; n <= a.GetNbins(); ++n) {
+            const double c_a = a.GetBinCenter(n);
+            const double c_b = b.GetBinCenter(n);
+            const double delta = c_a - c_b;
+            if( ( c_a && std::abs(delta/c_a) > rel_delta_max ) || ( !c_a && std::abs(delta) > delta_max ) )
+                return false;
+        }
+        return true;
+    }
+
+private:
+    std::shared_ptr<TFile> file;
+    size_t version;
+    std::map<Particle, HistPtr> masses;
+    std::map<Process, HistPtr> cross_sections, branching_ratios;
+    std::list<HistPtr> all_hists;
+};
+
+class ModelReaderFactory {
+public:
+    static std::shared_ptr<ModelReader> Make(const std::string& file_name, size_t version)
+    {
+        if(version >= 3)
+            throw exception("Model file version %1% is not supported.") % version;
+        return std::shared_ptr<ModelReader>(new ModelReader_Hist2D<TH2F>(file_name, version));
+    }
+private:
+    ModelReaderFactory() {}
+};
+
+class Model_MSSM : public Model {
+public:
+    Model_MSSM(const PointDescriptorCollection& _points)
+        : Model({ "m_A", "tan_beta" })
+    {
+        points = _points;
+    }
+};
+
+class Model_2HDM : public Model {
+public:
+    Model_2HDM(const PointDescriptorCollection& _points)
+        : Model({ "m_H", "tan_beta" })
+    {
+        points = _points;
+    }
+};
+
+
+class ModelFactory {
+public:
+    static std::shared_ptr<Model> Make(const std::string& name, std::shared_ptr<ModelReader> reader)
+    {
+        const auto points = reader->CollectAvailablePoints();
+        if(name == "MSSM")
+            return std::shared_ptr<Model>(new Model_MSSM(points));
+        else if(name == "2HDM")
+            return std::shared_ptr<Model>(new Model_2HDM(points));
+        throw exception("Model name '%1%' is not supported.") % name;
+    }
+
+private:
+    ModelFactory() {}
+};
+
+std::shared_ptr<TGraph2D> CreateTGraph2D(const std::string& name, const std::vector<double>& x_list,
+                                         const std::vector<double>& y_list, const std::vector<double>& z_list)
+{
+    std::vector<double> x_list_copy(x_list), y_list_copy(y_list), z_list_copy(z_list);
+    return std::shared_ptr<TGraph2D>(new TGraph2D(name.c_str(), name.c_str(), x_list.size(), x_list_copy.data(),
+                                                  y_list_copy.data(), z_list_copy.data()));
+}
+
+std::shared_ptr<TH2D> CreateTH2D(const std::string& name, std::shared_ptr<TH2F> ref_hist)
+{
+    const auto x_bins = ref_hist->GetXaxis()->GetXbins(), y_bins = ref_hist->GetYaxis()->GetXbins();
+    return std::shared_ptr<TH2D>(new TH2D(name.c_str(), name.c_str(), x_bins->GetSize() - 1, x_bins->GetArray(),
+                                          y_bins->GetSize() - 1, y_bins->GetArray()));
+}
+
+void CreateOutput(const std::vector<double>& x_list, const std::vector<double>& y_list,
+                  const std::vector<double>& z_list, std::shared_ptr<TFile> output_file, const std::string& name,
+                  const std::shared_ptr<TH2F> ref_hist, double excl_threshold = -std::numeric_limits<double>::infinity(),
+                  double graph_factor = 1, double graph_max = std::numeric_limits<double>::infinity(),
+                  bool interpolate = false)
+{
+    std::ostringstream ss_name;
+    ss_name << name << "_hist";
+    auto hist = CreateTH2D(ss_name.str(), ref_hist);
+    ss_name << "_excl";
+    auto hist_excl = CreateTH2D(ss_name.str(), ref_hist);
+
+    if(interpolate) {
+        auto ref_graph = CreateTGraph2D("ref_tmp", x_list, y_list, z_list);
+        for(Int_t x_id = 1; x_id <= hist->GetXaxis()->GetNbins(); ++x_id) {
+            const double x = hist->GetXaxis()->GetBinCenter(x_id);
+            for(Int_t y_id = 1; y_id <= hist->GetYaxis()->GetNbins(); ++y_id) {
+                const double y = hist->GetYaxis()->GetBinCenter(y_id);
+                const double z = ref_graph->Interpolate(x, y);
+                hist->SetBinContent(x_id, y_id, z);
+                if(z < excl_threshold)
+                    hist_excl->SetBinContent(x_id, y_id, 1.0);
+            }
+        }
+    } else {
+        for(size_t n = 0; n < z_list.size(); ++n) {
+            const Int_t bin_id = hist->FindBin(x_list.at(n), y_list.at(n));
+            const double z =  z_list.at(n);
+            hist->SetBinContent(bin_id, z);
+            if(z < excl_threshold)
+                hist_excl->SetBinContent(bin_id, 1.0);
+        }
+    }
+
+    std::vector<double> z_list_graph(z_list.size());
+    for(size_t n = 0; n < z_list.size(); ++n)
+        z_list_graph.at(n) = std::min(graph_max, z_list.at(n) * graph_factor);
+    auto graph = CreateTGraph2D(name, x_list, y_list, z_list_graph);
+
+    output_file->WriteTObject(graph.get(), nullptr, "Overwrite");
+    output_file->WriteTObject(hist.get(), nullptr, "Overwrite");
+    output_file->WriteTObject(hist_excl.get(), nullptr, "Overwrite");
+}
+
+struct Arguments : run::ArgumentsBase {
+    StrArg input{ "input", "input directory with limit files" };
+    StrArg output{ "output", "output ROOT file with model dependent interpretation" };
+    StrArg model{ "model", "physical model", "MSSM" };
+    StrArg model_file{ "model-file", "ROOT file with model description" };
+    Arg<size_t> model_file_version{ "model-file-version", "Version of the model file", 1 };
+    Arg<CompositProcess> process{ "process", "process name" };
+    Arg<Range<double>> range_x{ "range-x", "x range in format min:max" };
+    Arg<Range<double>> range_y{ "range-y", "y range in format min:max" };
+    Arg<Units> units{ "units", "units in which limits are given", Units::pb };
+};
+
+class SimpleHHInterpret {
+public:
+    using Range = ::analysis::Range<double>;
+    using RangeMultiD = ::analysis::RangeMultiD<Range>;
+    using InterpolatorVec = std::vector<InterpolatorPtr>;
+
+    SimpleHHInterpret(const Arguments& _args) : args(_args) {}
+
+    void Run()
+    {
+        const RangeMultiD param_range({ args.range_x(), args.range_y() });
+        Range m_H_range;
+        const auto& limits = ReadInterpolatedLimits(args.input(), m_H_range, args.units());
+        const auto model_reader = ModelReaderFactory::Make(args.model_file(), args.model_file_version());
+        const auto model = ModelFactory::Make(args.model(), model_reader);
+        std::vector<double> x_list, y_list, z_list_pred;
+        std::vector<std::vector<double>> z_list(limits.size());
+
+        for(const auto& desc : model->GetAvailablePoints()) {
+            if(!param_range.Contains(desc.point)) continue;
+            const double th_predicted = std::max(desc.GetProcessBR_CS(args.process()), 0.0);
+            const double m_H = desc.GetMass(Particle::H);
+            if(!m_H_range.Contains(m_H) || !th_predicted) continue;
+            x_list.push_back(desc.point.at(0));
+            y_list.push_back(desc.point.at(1));
+            z_list_pred.push_back(th_predicted);
+            for(size_t n = 0; n < limits.size(); ++n) {
+                const double r = limits.at(n)->Eval(m_H) / th_predicted;
+                z_list.at(n).push_back(r);
+            }
+        }
+
+        const auto ref_hist = model_reader->GetReferenceHistogram();
+        auto output_file = root_ext::CreateRootFile(args.output());
+        for(size_t n = 0; n < limits.size(); ++n)
+            CreateOutput(x_list, y_list, z_list.at(n), output_file, all_limit_quantile_names.at(n), ref_hist,
+                         1.0, 0.05, 1.0);
+        CreateOutput(x_list, y_list, z_list_pred, output_file, "predicted_CS_BR", ref_hist);
+
+        std::cout << "File '" << args.output() << "' successfully created.\n";
+    }
+
+private:
+    InterpolatorVec ReadInterpolatedLimits(const std::string& input_dir_name, Range& mass_range, Units units)
+    {
+        const auto& file_names = GetOrderedFileList(input_dir_name, ".*\\.root");
+        std::vector<std::vector<double>> limits(all_limit_quantiles.size());
+        std::set<double> masses;
+        const double units_factor = GetUnitsFactor(units);
+
+        if(!file_names.size())
+            throw exception("No input files are found.");
+
+        for(const auto& file_entry : file_names) {
+            const std::string& file_name = file_entry.second;
+            const double mass = file_entry.first;
+            std::cout << "Reading " << file_name << std::endl;
+            if(masses.count(mass))
+                throw exception("More than one file with for the mass point = %1%") % mass;
+
+            masses.insert(mass);
+            std::shared_ptr<TFile> file(new TFile(file_name.c_str(), "READ"));
+            std::shared_ptr<TTree> tree(dynamic_cast<TTree*>(file->Get("limit")));
+            double limit;
+            float quantileExpected;
+            tree->SetBranchAddress("limit", &limit);
+            tree->SetBranchAddress("quantileExpected", &quantileExpected);
+            for(Long64_t n = 0; n < tree->GetEntries(); ++n) {
+                tree->GetEntry(n);
+                const size_t quantile_id = GetQuantileId(quantileExpected);
+                limits.at(quantile_id).push_back(limit * units_factor);
+            }
+        }
+
+        const std::vector<double> mass_vec(masses.begin(), masses.end());
+        mass_range = Range(mass_vec.front(), mass_vec.back());
+        InterpolatorVec interps;
+        for(size_t n = 0; n < limits.size(); ++n) {
+            if(limits[n].size() != masses.size())
+                throw exception("Inconsistent input limits.");
+            InterpolatorPtr interp(new ROOT::Math::Interpolator(mass_vec, limits[n], ROOT::Math::Interpolation::kCSPLINE));
+            interps.push_back(interp);
+        }
+        return interps;
+    }
+
+private:
+    Arguments args;
+};
+
+} // namespace hh_analysis
+
+PROGRAM_MAIN(hh_analysis::SimpleHHInterpret, hh_analysis::Arguments)

--- a/StatModels/interface/Config.h
+++ b/StatModels/interface/Config.h
@@ -1,0 +1,30 @@
+/*! Functions to read stat model configuration.
+This file is part of https://github.com/cms-hh/HHStatAnalysis. */
+
+#pragma once
+
+#include "HHStatAnalysis/Core/interface/ConfigReader.h"
+#include "HHStatAnalysis/StatModels/interface/ModelConfigEntryReader.h"
+
+namespace hh_analysis {
+
+inline void ReadConfig(const std::string& cfg_name, ModelDescriptorCollection& descs)
+{
+    analysis::ConfigReader config_reader;
+
+    ModelConfigEntryReader reader(descs);
+    config_reader.AddEntryReader("MODEL", reader, true);
+
+    config_reader.ReadConfig(cfg_name);
+}
+
+inline StatModelDescriptor LoadDescriptor(const std::string& cfg_name, const std::string& model_desc)
+{
+    ModelDescriptorCollection descs;
+    ReadConfig(cfg_name, descs);
+    if(!descs.count(model_desc))
+        throw analysis::exception("Unable to find %1% in %2%.") % model_desc % cfg_name;
+    return descs.at(model_desc);
+}
+
+} // namespace hh_analysis

--- a/StatModels/interface/ModelConfigEntryReader.h
+++ b/StatModels/interface/ModelConfigEntryReader.h
@@ -1,0 +1,69 @@
+/*! Definition of the stat model configuration entry reader.
+This file is part of https://github.com/cms-hh/HHStatAnalysis. */
+
+#pragma once
+
+#include "HHStatAnalysis/Core/interface/ConfigReader.h"
+#include "StatModelDescriptor.h"
+
+namespace hh_analysis {
+
+class ModelConfigEntryReader : public analysis::ConfigEntryReader {
+public:
+    ModelConfigEntryReader(ModelDescriptorCollection& _descriptors) : descriptors(&_descriptors) {}
+
+    virtual void StartEntry(const std::string& name, const std::string& reference_name) override
+    {
+        ConfigEntryReader::StartEntry(name, reference_name);
+        current = StatModelDescriptor();
+        current = reference_name.size() ? descriptors->at(reference_name) : StatModelDescriptor();
+        current.name = name;
+    }
+
+    virtual void EndEntry() override
+    {
+        CheckReadParamCounts("stat_model", 1, Condition::less_equal);
+        CheckReadParamCounts("channels", 1, Condition::less_equal);
+        CheckReadParamCounts("categories", 1, Condition::less_equal);
+        CheckReadParamCounts("signal_process", 1, Condition::less_equal);
+        CheckReadParamCounts("model_signal_process", 1, Condition::less_equal);
+        CheckReadParamCounts("signal_point_prefix", 1, Condition::less_equal);
+        CheckReadParamCounts("signal_points", 1, Condition::less_equal);
+        CheckReadParamCounts("limit_type", 1, Condition::less_equal);
+        CheckReadParamCounts("th_model_file", 1, Condition::less_equal);
+        CheckReadParamCounts("blind", 1, Condition::less_equal);
+        CheckReadParamCounts("morph", 1, Condition::less_equal);
+        CheckReadParamCounts("combine_channels", 1, Condition::less_equal);
+        CheckReadParamCounts("grid_x", 1, Condition::less_equal);
+        CheckReadParamCounts("grid_y", 1, Condition::less_equal);
+
+        (*descriptors)[current.name] = current;
+    }
+
+    virtual void ReadParameter(const std::string& /*param_name*/, const std::string& /*param_value*/,
+                               std::istringstream& /*ss*/) override
+    {
+        ParseEntry("stat_model", current.stat_model);
+        ParseEntryList("channels", current.channels);
+        ParseEntryList("categories", current.categories);
+        ParseEntry("signal_process", current.signal_process);
+        ParseEntry("model_signal_process", current.model_signal_process);
+        ParseEntry("signal_point_prefix", current.signal_point_prefix);
+        ParseEntryList("signal_points", current.signal_points);
+        ParseEntry("limit_type", current.limit_type);
+        ParseEntry("th_model_file", current.th_model_file);
+        ParseEntry("blind", current.blind);
+        ParseEntry("morph", current.morph);
+        ParseEntry("combine_channels", current.combine_channels);
+        ParseEntry("per_channel_limits", current.per_channel_limits);
+        ParseEntry("grid_x", current.grid_x);
+        ParseEntry("grid_y", current.grid_y);
+        ParseEntry("custom_param", current.custom_params);
+    }
+
+private:
+    StatModelDescriptor current;
+    ModelDescriptorCollection* descriptors;
+};
+
+} // namespace hh_analysis

--- a/StatModels/interface/StatModel.h
+++ b/StatModels/interface/StatModel.h
@@ -1,9 +1,10 @@
 /*! Definition of the base class for HH stat models.
-This file is part of https://github.com/cms-hh/StatAnalysis. */
+This file is part of https://github.com/cms-hh/HHStatAnalysis. */
 
 #pragma once
 
 #include "CombineHarvester/CombineTools/interface/CombineHarvester.h"
+#include "StatModelDescriptor.h"
 
 namespace hh_analysis {
 namespace stat_models {
@@ -15,8 +16,17 @@ public:
 
     static const v_str wildcard;
 
+    StatModel(const StatModelDescriptor& _desc) : desc(_desc) {}
+
     virtual ~StatModel() {}
-    virtual void CreateDatacards(const std::string& shapes_path, const std::string& output_path) = 0;
+    virtual void CreateDatacards(const std::string& shapes_file, const std::string& output_path) = 0;
+
+    static void FixNegativeBins(ch::CombineHarvester& harvester);
+    static void RenameProcess(ch::CombineHarvester& harvester, const std::string& old_name,
+                              const std::string& new_name);
+
+protected:
+    StatModelDescriptor desc;
 };
 
 using StatModelPtr = std::shared_ptr<StatModel>;

--- a/StatModels/interface/StatModelDescriptor.h
+++ b/StatModels/interface/StatModelDescriptor.h
@@ -1,0 +1,56 @@
+/*! Definition of the stat model descriptor.
+This file is part of https://github.com/cms-hh/HHStatAnalysis. */
+
+#pragma once
+
+#include <map>
+#include "HHStatAnalysis/Core/interface/EnumNameMap.h"
+#include "HHStatAnalysis/Core/interface/TextIO.h"
+#include "HHStatAnalysis/Core/interface/NumericPrimitives.h"
+
+namespace hh_analysis {
+using namespace analysis;
+
+enum class LimitType { ModelIndependent, MSSM };
+ENUM_NAMES(LimitType) = {
+    { LimitType::ModelIndependent, "model_independent" },
+    { LimitType::MSSM, "MSSM" }
+};
+
+struct StatModelDescriptor {
+    std::string name;
+    std::string stat_model;
+    std::vector<std::string> channels;
+    std::vector<std::string> categories;
+    std::string signal_process, model_signal_process;
+    std::string signal_point_prefix;
+    std::vector<std::string> signal_points;
+
+    LimitType limit_type;
+    std::string th_model_file;
+    bool blind, morph, combine_channels, per_channel_limits;
+    RangeWithStep<double> grid_x, grid_y;
+
+
+    std::map<std::string, std::string> custom_params;
+
+    template<typename T = std::string>
+    T at(const std::string& key) const
+    {
+        if(!custom_params.count(key))
+            throw exception("Custom parameter '%1%' not found.") % key;
+        T value;
+        const std::string& str_value = custom_params.at(key);
+        if(!TryParse(str_value, value))
+            throw exception("Unable to parse a value ('%1%') of the custom parameter '%2%'. ") % str_value % key;
+        return value;
+    }
+
+    StatModelDescriptor() :
+        limit_type(LimitType::ModelIndependent), blind(true), morph(false), combine_channels(true),
+        per_channel_limits(false) {}
+};
+
+using ModelDescriptorCollection = std::unordered_map<std::string, StatModelDescriptor>;
+
+} // namespace hh_analysis

--- a/StatModels/interface/StatModelFactory.h
+++ b/StatModels/interface/StatModelFactory.h
@@ -1,10 +1,11 @@
 /*! Definition of the HH StatModel factory.
-This file is part of https://github.com/cms-hh/StatAnalysis. */
+This file is part of https://github.com/cms-hh/HHStatAnalysis. */
 
 #pragma once
 
 #include <unordered_set>
 #include "StatModel.h"
+#include "StatModelDescriptor.h"
 
 namespace hh_analysis {
 namespace stat_models {
@@ -12,7 +13,7 @@ namespace stat_models {
 class StatModelFactory {
 public:
     using ModelNameSet = std::unordered_set<std::string>;
-    static StatModelPtr Make(const std::string& model_name);
+    static StatModelPtr Make(const StatModelDescriptor& model_desc);
     static const ModelNameSet& AvailableModelNames();
     static void ReportAvailableModelNames(std::ostream& os);
 

--- a/StatModels/interface/bbtautau_Resonant.h
+++ b/StatModels/interface/bbtautau_Resonant.h
@@ -1,5 +1,5 @@
 /*! Stat model for X->hh->bbtautau.
-This file is part of https://github.com/cms-hh/StatAnalysis. */
+This file is part of https://github.com/cms-hh/HHStatAnalysis. */
 
 #pragma once
 
@@ -10,30 +10,27 @@ namespace stat_models {
 
 class bbtautau_Resonant : public StatModel {
 public:
-    static const std::string file_name_suffix;
-    static const v_double masses;
-    static const v_str masses_str;
     static const v_str ana_name;
     static const v_str eras;
-    static const v_str channels;
-    static const ch::Categories categories;
-    static const v_str signal_processes;
     static const v_str bkg_mc_processes;
     static const v_str bkg_data_driven_processes;
     static const v_str bkg_all_processes;
-    static const v_str all_mc_processes;
 
     static constexpr double bbb_unc_threshold = 0.1;
     static constexpr double bin_merge_threashold = 0.5;
 
-    virtual void CreateDatacards(const std::string& shapes_path, const std::string& output_path) override;
+    bbtautau_Resonant(const StatModelDescriptor& _desc);
+    virtual void CreateDatacards(const std::string& shapes_file, const std::string& output_path) override;
 
 private:
     void AddSystematics(ch::CombineHarvester& combine_harvester);
-    static std::pair<std::string, std::string> ShapeNameRule(bool use_mass);
-    static void ExtractShapes(ch::CombineHarvester& combine_harvester, const std::string& path, bool is_signal);
-    static ch::Categories GetChannelCategories(const std::string& channel);
-    static std::string FullFileName(const std::string& path, const std::string& channel);
+    std::pair<std::string, std::string> ShapeNameRule(bool use_mass) const;
+    void ExtractShapes(ch::CombineHarvester& combine_harvester, const std::string& shapes_file, bool is_signal) const;
+    ch::Categories GetChannelCategories(const std::string& channel);
+    std::string FullFileName(const std::string& path, const std::string& channel) const;
+
+private:
+    const v_str signal_processes, all_mc_processes;
 };
 
 } // namespace stat_models

--- a/StatModels/python/run_hh_limits_helpers.py
+++ b/StatModels/python/run_hh_limits_helpers.py
@@ -1,0 +1,29 @@
+# run_hh_limits helpers.
+# This file is part of https://github.com/cms-hh/HHStatAnalysis.
+
+import sys
+import os
+import subprocess
+from HHStatAnalysis.StatModels.terminal import colored, bcolors
+
+def run_failed(message):
+    print >> sys.stderr, colored("run_hh_limits failed:", bcolors.FAIL), '{}.'.format(message)
+    sys.exit(1)
+
+def run_succeed():
+    print colored("run_hh_limits successfully finished.", bcolors.OKGREEN)
+    sys.exit(0)
+
+def check_result(result, message):
+    if result != 0:
+        run_failed(message)
+
+def sh_call(cmd, error_message):
+    result = subprocess.call([cmd], shell=True)
+    check_result(result, error_message)
+
+def ch_dir(path):
+    try:
+        os.chdir(path)
+    except OSError:
+        run_failed("error while changing working directory to '{}'".format(path))

--- a/StatModels/python/terminal.py
+++ b/StatModels/python/terminal.py
@@ -1,0 +1,15 @@
+# Terminal helpers.
+# This file is part of https://github.com/cms-hh/HHStatAnalysis.
+
+class bcolors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+def colored(message, color):
+    return color + message + bcolors.ENDC

--- a/StatModels/scripts/run_hh_limits.py
+++ b/StatModels/scripts/run_hh_limits.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+# Run hh limits.
+# This file is part of https://github.com/cms-hh/HHStatAnalysis.
+
+import os
+import argparse
+import glob
+import json
+from HHStatAnalysis.StatModels.run_hh_limits_helpers import *
+import libHHStatAnalysisStatModels as HH
+
+parser = argparse.ArgumentParser(description='Run hh limits.',
+                  formatter_class = lambda prog: argparse.HelpFormatter(prog, max_help_position=30, width=90))
+parser.add_argument('--cfg', required=True, dest='cfg', type=str, metavar='FILE', help="configuration file")
+parser.add_argument('--model-desc', required=True, dest='model_desc', type=str, metavar='DESC',
+                    help="name of the stat model descriptor in the config")
+parser.add_argument('--output', required=True, dest='output_path', type=str, metavar='PATH',
+                    help="path were to store limits")
+parser.add_argument('--parallel', required=False, dest='n_parallel', type=int, default=8, metavar='N',
+                    help="number of parallel jobs")
+parser.add_argument('shapes_file', type=str, nargs='+', help="file with input shapes")
+
+args = parser.parse_args()
+
+limit_json_name = "limits"
+limit_json_file = limit_json_name + ".json"
+limit_json_pattern = limit_json_name + "_*.json"
+
+if not os.path.exists(args.output_path):
+    os.makedirs(args.output_path)
+
+shapes_file = args.shapes_file[0]
+if len(args.shapes_file) > 1:
+    shapes_file = '{}/shapes.root'.format(args.output_path)
+    hadd_command = 'hadd -f9 {}'.format(shapes_file)
+    for file in args.shapes_file:
+        hadd_command += '"{}"'.format(file)
+    sh_call(hadd_command, "error while executing hadd for input files")
+
+model_desc = HH.LoadDescriptor(args.cfg, args.model_desc)
+
+sh_call('create_hh_datacards --cfg {} --model-desc {} --shapes {} --output {}'
+        .format(args.cfg, args.model_desc, shapes_file, args.output_path),
+        "error while executing create_hh_datacards")
+
+limit_type = str(model_desc.limit_type)
+if limit_type == 'model_independent':
+    ch_dir(args.output_path)
+    sh_call('combineTool.py -M T2W -i */* -o workspace.root --parallel {}'.format(args.n_parallel),
+            "error while executing text to workspace")
+
+    sh_call('combineTool.py -M Asymptotic -d */*/workspace.root --there -n .limit --parallel {}'.format(
+            args.n_parallel), "error while executing combine")
+
+    sh_call('combineTool.py -M CollectLimits */*/*.limit.* --use-dirs -o {}'.format(limit_json_file),
+            "error while collecting limits")
+
+    limits_to_show = "exp"
+    if not model_desc.blind:
+        limits_to_show += ",obs"
+
+    for input_file in glob.glob(limit_json_pattern):
+        output_name = os.path.splitext(input_file)[0]
+        sh_call('plotLimits.py {} --output {} --auto-style --y-title \'{}\' --logy --show {}'.format(input_file,
+                output_name, "95% CL limit on #sigma (pb)", limits_to_show), "error while plotting limits")
+
+elif limit_type == 'MSSM':
+    th_model_file_full_path = os.path.abspath(model_desc.th_model_file)
+    th_models_path, th_model_file = os.path.split(th_model_file_full_path)
+    ch_dir(args.output_path)
+
+    grid_dict = { 'opts'  : '--singlePoint 1.0', 'POIs'  : [ 'mA', 'tanb' ], 'grids' : [] }
+    grid_dict['grids'].append([
+        '{}:{}|{}'.format(model_desc.grid_x.min(), model_desc.grid_x.max(), model_desc.grid_x.step()),
+        '{}:{}|{}'.format(model_desc.grid_y.min(), model_desc.grid_y.max(), model_desc.grid_y.step()),
+        ''
+    ])
+    grid_file_name = 'asymptotic_grid.json'
+    grid_file = open(grid_file_name, 'w')
+    grid_file.write(json.dumps(grid_dict))
+    grid_file.close()
+
+    plotLimitGrid = os.environ['CMSSW_BASE'] + '/src/CombineHarvester/CombineTools/scripts/plotLimitGrid.py'
+    contours = "exp-2,exp-1,exp0,exp+1,exp+2"
+    if not model_desc.blind:
+        contours += ",obs"
+    workspace_file = "MSSM.root"
+
+    channels = filter(lambda f: os.path.isdir(f), os.listdir('.'))
+    for channel in channels:
+
+        sh_call('combineTool.py -M T2W -o {} -P {} --PO filePrefix={}/ --PO modelFiles=13TeV,{},1 -i {}'.format(
+                workspace_file, 'CombineHarvester.CombinePdfs.MSSM:MSSM', th_models_path, th_model_file, channel),
+                "error while executing text to workspace")
+
+        work_path = channel + '/work'
+        os.makedirs(work_path)
+        ch_dir(work_path)
+
+        asymptoticGrid_cmd = 'combineTool.py -M AsymptoticGrid ../../{} -d ../{} --parallel {}'.format(
+                             grid_file_name, workspace_file, args.n_parallel)
+        sh_call(asymptoticGrid_cmd, "error while executing combine")
+        sh_call(asymptoticGrid_cmd, "error while collecting jobs")
+
+        output_name = '../../limits_{}_{}'.format(model_desc.limit_type, channel)
+        sh_call('{} {} --output {} --contours {}'.format(plotLimitGrid, 'asymptotic_grid.root', output_name, contours),
+                "error while plotting limits")
+
+        ch_dir('../..')
+
+else:
+    run_failed("limit type '{}' not supported".format(model_desc.limit_type))
+
+run_succeed()

--- a/StatModels/src/StatModel.cc
+++ b/StatModels/src/StatModel.cc
@@ -1,5 +1,5 @@
 /*! Implementation of the base class for HH stat models.
-This file is part of https://github.com/cms-hh/StatAnalysis. */
+This file is part of https://github.com/cms-hh/HHStatAnalysis. */
 
 #include "HHStatAnalysis/StatModels/interface/StatModel.h"
 
@@ -7,6 +7,26 @@ namespace hh_analysis {
 namespace stat_models {
 
 const StatModel::v_str StatModel::wildcard = { "*" };
+
+void StatModel::FixNegativeBins(ch::CombineHarvester& harvester)
+{
+    harvester.ForEachProc([](ch::Process *p) {
+        if(!ch::HasNegativeBins(p->shape())) return;
+        std::cout << "[Negative bins] Fixing negative bins for " << p->bin() << "," << p->process() << "\n";
+        auto new_shape = p->ClonedShape();
+        ch::ZeroNegativeBins(new_shape.get());
+        p->set_shape(std::move(new_shape), false);
+    });
+}
+
+void StatModel::RenameProcess(ch::CombineHarvester& harvester, const std::string& old_name, const std::string& new_name)
+{
+    harvester.ForEachObj([&](ch::Object *obj) {
+        if(obj->process() == old_name)
+            obj->set_process(new_name);
+    });
+}
+
 
 } // namespace stat_models
 } // namespace hh_analysis

--- a/StatModels/src/StatModelFactory.cc
+++ b/StatModels/src/StatModelFactory.cc
@@ -1,5 +1,5 @@
 /*! Implementation of the HH StatModel factory.
-This file is part of https://github.com/cms-hh/StatAnalysis. */
+This file is part of https://github.com/cms-hh/HHStatAnalysis. */
 
 #include <unordered_map>
 
@@ -12,13 +12,13 @@ namespace stat_models {
 
 namespace {
 
-using ProducerFn = StatModelPtr (*)();
+using ProducerFn = StatModelPtr (*)(const StatModelDescriptor& model_desc);
 using ProducerFnMap = std::unordered_map<std::string, ProducerFn>;
 
 template<typename Model>
-StatModelPtr DefaultProducer()
+StatModelPtr DefaultProducer(const StatModelDescriptor& model_desc)
 {
-    return StatModelPtr(new Model());
+    return StatModelPtr(new Model(model_desc));
 }
 
 const ProducerFnMap& GetProducerFunctions()
@@ -55,15 +55,15 @@ void StatModelFactory::ReportAvailableModelNames(std::ostream& os)
     os << ".";
 }
 
-StatModelPtr StatModelFactory::Make(const std::string& model_name)
+StatModelPtr StatModelFactory::Make(const StatModelDescriptor& model_desc)
 {
-    if(!GetProducerFunctions().count(model_name)) {
+    if(!GetProducerFunctions().count(model_desc.stat_model)) {
         std::ostringstream ss;
-        ss << "Unknown model name '" << model_name << "'.\n";
+        ss << "Unknown model name '" << model_desc.stat_model << "'.\n";
         ReportAvailableModelNames(ss);
         throw exception(ss.str());
     }
-    return GetProducerFunctions().at(model_name)();
+    return GetProducerFunctions().at(model_desc.stat_model)(model_desc);
 }
 
 } // namespace stat_models

--- a/StatModels/src/StatModelsPy.cc
+++ b/StatModels/src/StatModelsPy.cc
@@ -1,0 +1,61 @@
+/*! Python interface for HH stat models.
+This file is part of https://github.com/cms-hh/HHStatAnalysis. */
+
+#include <boost/python.hpp>
+#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
+#include <boost/python/suite/indexing/map_indexing_suite.hpp>
+#include "HHStatAnalysis/StatModels/interface/Config.h"
+
+namespace {
+template <typename T>
+boost::python::list ToPythonList(const std::vector<T>& v)
+{
+    boost::python::list l;
+    for(const auto& item : v)
+        l.append(item);
+    return l;
+}
+
+template <typename Key, typename Value>
+boost::python::dict ToPythonDict(const std::map<Key, Value>& m)
+{
+    boost::python::dict d;
+    for(const auto& item : m)
+        d[item.first] = item.second;
+    return d;
+}
+} // anonymous namespace
+
+BOOST_PYTHON_MODULE(libHHStatAnalysisStatModels)
+{
+    using StrVector = std::vector<std::string>;
+    using StrStrMap = std::map<std::string, std::string>;
+    using StrVectMap = std::map<std::string, StrVector>;
+    using namespace boost::python;
+    using namespace hh_analysis;
+    class_<StrVector>("StrVector")
+        .def(vector_indexing_suite<StrVector>());
+    class_<StrStrMap>("StrStrMap")
+        .def(map_indexing_suite<StrStrMap>());
+    class_<StrVectMap>("StrVectMap")
+        .def(map_indexing_suite<StrVectMap>());
+    enum_<LimitType>("LimitType")
+        .value("model_independent", LimitType::ModelIndependent)
+        .value("MSSM", LimitType::MSSM);
+    class_<RangeWithStep<double>>("RangeWithStep", init<>())
+        .def(init<double, double, double>())
+        .def("min", &RangeWithStep<double>::min)
+        .def("max", &RangeWithStep<double>::max)
+        .def("step", &RangeWithStep<double>::step);
+    class_<StatModelDescriptor>("StatModelDescriptor")
+        .def_readwrite("name", &StatModelDescriptor::name)
+        .def_readwrite("channels", &StatModelDescriptor::channels)
+        .def_readwrite("limit_type", &StatModelDescriptor::limit_type)
+        .def_readwrite("blind", &StatModelDescriptor::blind)
+        .def_readwrite("grid_x", &StatModelDescriptor::grid_x)
+        .def_readwrite("grid_y", &StatModelDescriptor::grid_y)
+        .def_readwrite("th_model_file", &StatModelDescriptor::th_model_file);
+    def("LoadDescriptor", LoadDescriptor);
+    def("ToList", ToPythonList<std::string>);
+    def("ToDict", ToPythonDict<std::string, std::string>);
+}

--- a/StatModels/src/bbtautau_Resonant.cc
+++ b/StatModels/src/bbtautau_Resonant.cc
@@ -12,7 +12,7 @@ namespace stat_models {
 
 const std::string bbtautau_Resonant::file_name_suffix = "m_ttbb_MassWindow";
 const StatModel::v_double bbtautau_Resonant::masses = {
-    250, 260, 270, 280, 300, 320, 340, 350, 400, 450, 500, 550, 600, 650, 700, 800, 900
+    250, 260, 270, 280, 320, 340, 450, 500, 550, 600, 650, 700,750, 800, 900
 };
 
 const StatModel::v_str bbtautau_Resonant::masses_str = ToStrVector(bbtautau_Resonant::masses);
@@ -23,7 +23,7 @@ const ch::Categories bbtautau_Resonant::categories = {
     { 0, "2jet0tag" }, { 1, "2jet1tag" }, { 2, "2jet2tag" }
 };
 const StatModel::v_str bbtautau_Resonant::signal_processes = { "ggRadionTohhTo2Tau2B" };
-const StatModel::v_str bbtautau_Resonant::bkg_mc_processes = { "TT", "ZTT", "VV", "W" };
+const StatModel::v_str bbtautau_Resonant::bkg_mc_processes = { "TT", "ZTT", /*"VV",*/ "W" };
 const StatModel::v_str bbtautau_Resonant::bkg_data_driven_processes = { "QCD" };
 const StatModel::v_str bbtautau_Resonant::bkg_all_processes
                                         = ch::JoinStr({ bkg_mc_processes, bkg_data_driven_processes });
@@ -119,14 +119,18 @@ void bbtautau_Resonant::AddSystematics(ch::CombineHarvester& cb)
     using ch::syst::SystMap;
     ch::CombineHarvester h = cb.cp();
     const auto& sig = ch::Set2Vec(cb.cp().signals().process_set());
-    const std::vector<std::string> bkg_mc = {"TT", "ZTT", "VV", "W"};
-    const std::vector<std::string> mc_samples = ch::JoinStr({ sig, {"TT", "ZTT", "VV", "W"}});
+    const std::vector<std::string> bkg_mc = {"TT", "ZTT", /*"VV", */"W"};
+    const std::vector<std::string> mc_samples = ch::JoinStr({ sig, {"TT", "ZTT", /*"VV", */"W"}});
 
     h.cp().process(mc_samples).AddSyst(cb, "lumi_13TeV", "lnN", SystMap<>::init(1.027));
     h.cp().process(sig).AddSyst(cb, "scale_j_13TeV", "lnN", SystMap<>::init(1.02));
     h.cp().process(bkg_mc).AddSyst(cb, "scale_j_13TeV", "lnN", SystMap<>::init(1.04));
     h.cp().process({"TT"}).AddSyst(cb, "TT_xs_13TeV", "lnN", SystMap<>::init(1.05));
-    h.cp().process(mc_samples).AddSyst(cb, "CMS_scale_t_mutau_13TeV", "shape", SystMap<>::init(1));
+    h.cp().process(mc_samples).AddSyst(cb, "scale_b", "lnN", SystMap<>::init(1.02));
+    h.cp().process(mc_samples).AddSyst(cb, "eff_btag", "lnN", SystMap<>::init(1.03));
+    h.cp().process(mc_samples).AddSyst(cb, "eff_t", "lnN", SystMap<>::init(1.06));
+    h.cp().process(mc_samples).AddSyst(cb, "eff_m", "lnN", SystMap<>::init(1.018));
+    h.cp().process({"QCD"}).AddSyst(cb, "qcd_norm", "lnN", SystMap<>::init(1.06));
 }
 
 } // namespace stat_models

--- a/StatModels/src/bbtautau_Resonant.cc
+++ b/StatModels/src/bbtautau_Resonant.cc
@@ -1,116 +1,108 @@
 /*! Stat model for X->hh->bbtautau.
-This file is part of https://github.com/cms-hh/StatAnalysis. */
+This file is part of https://github.com/cms-hh/HHStatAnalysis. */
 
 #include <iostream>
 #include "CombineHarvester/CombineTools/interface/Systematics.h"
+#include "CombineHarvester/CombineTools/interface/CardWriter.h"
+#include "CombineHarvester/CombinePdfs/interface/MorphFunctions.h"
 #include "HHStatAnalysis/StatModels/interface/bbtautau_Resonant.h"
 #include "HHStatAnalysis/Core/interface/exception.h"
 #include "HHStatAnalysis/Core/interface/Tools.h"
+#include "HHStatAnalysis/Core/interface/TextIO.h"
+#include "HHStatAnalysis/Core/interface/RootExt.h"
 
 namespace hh_analysis {
 namespace stat_models {
 
-const std::string bbtautau_Resonant::file_name_suffix = "m_ttbb_kinfit_KinFitConvergedWithMassWindow";
-const StatModel::v_double bbtautau_Resonant::masses = {
-    250, 260, 270, 280, 320, 340, 450, 500, 550, 600, 650, 700,750, 800, 900
-};
-
-const StatModel::v_str bbtautau_Resonant::masses_str = ToStrVector(bbtautau_Resonant::masses);
-const StatModel::v_str bbtautau_Resonant::ana_name = { "HHbbtt" };
+const StatModel::v_str bbtautau_Resonant::ana_name = { "hh_ttbb" };
 const StatModel::v_str bbtautau_Resonant::eras = { "13TeV" };
-const StatModel::v_str bbtautau_Resonant::channels = { "muTau" };
-const ch::Categories bbtautau_Resonant::categories = {
-    { 0, "2jet0tag" }, { 1, "2jet1tag" }, { 2, "2jet2tag" }
-};
-const StatModel::v_str bbtautau_Resonant::signal_processes = { "ggRadionTohhTo2Tau2B" };
-const StatModel::v_str bbtautau_Resonant::bkg_mc_processes = { "TT", "ZTT", /*"VV",*/ "W" };
+const StatModel::v_str bbtautau_Resonant::bkg_mc_processes = { "DY_0b", "DY_1b", "DY_2b", "TT", "tW", "VV", "W" };
 const StatModel::v_str bbtautau_Resonant::bkg_data_driven_processes = { "QCD" };
 const StatModel::v_str bbtautau_Resonant::bkg_all_processes
                                         = ch::JoinStr({ bkg_mc_processes, bkg_data_driven_processes });
-const StatModel::v_str bbtautau_Resonant::all_mc_processes = ch::JoinStr({ signal_processes, bkg_mc_processes });
 
-std::pair<std::string, std::string> bbtautau_Resonant::ShapeNameRule(bool use_mass)
+bbtautau_Resonant::bbtautau_Resonant(const StatModelDescriptor& _desc) :
+    StatModel(_desc), signal_processes({ desc.signal_process }),
+    all_mc_processes(ch::JoinStr({ signal_processes, bkg_mc_processes }))
 {
+}
 
+std::pair<std::string, std::string> bbtautau_Resonant::ShapeNameRule(bool use_mass) const
+{
     std::pair<std::string, std::string> result;
     std::ostringstream ss;
     ss << "$BIN/$PROCESS";
     if(use_mass)
-        ss << "$MASS";
+        ss << "_" << desc.signal_point_prefix << "$MASS";
     result.first = ss.str();
     ss << "_$SYSTEMATIC";
     result.second = ss.str();
     return result;
 }
 
-void bbtautau_Resonant::ExtractShapes(ch::CombineHarvester& combine_harvester, const std::string& path, bool is_signal)
+void bbtautau_Resonant::ExtractShapes(ch::CombineHarvester& combine_harvester, const std::string& shapes_file,
+                                      bool is_signal) const
 {
     const auto& processes = is_signal ? signal_processes : bkg_all_processes;
     const auto& shape_name_rules = ShapeNameRule(is_signal);
-    for(const auto& channel : channels) {
-        const auto& file_name = FullFileName(path, channel);
-        combine_harvester.cp().channel({channel}).process(processes)
-                .ExtractShapes(file_name, shape_name_rules.first, shape_name_rules.second);
-    }
+    combine_harvester.cp().process(processes).ExtractShapes(shapes_file, shape_name_rules.first,
+                                                            shape_name_rules.second);
 }
 
 ch::Categories bbtautau_Resonant::GetChannelCategories(const std::string& channel)
 {
     ch::Categories ch_categories;
-    for(const auto& category : categories) {
-        const std::string name = boost::str(boost::format("%1%_%2%") % channel % category.second);
-        ch_categories.push_back({category.first, name});
+    for(size_t n = 0; n < desc.categories.size(); ++n) {
+        const std::string cat_name = desc.categories.at(n);
+        const std::string name = boost::str(boost::format("%1%_%2%") % channel % cat_name);
+        ch_categories.push_back({n, name});
     }
     return ch_categories;
 }
 
-std::string bbtautau_Resonant::FullFileName(const std::string& path, const std::string& channel)
-{
-    const std::string file_name = boost::str(boost::format("%1%_%2%.root") % channel % file_name_suffix);
-    return FullPath({path, file_name});
-}
-
-void bbtautau_Resonant::CreateDatacards(const std::string& shapes_path, const std::string& output_path)
+void bbtautau_Resonant::CreateDatacards(const std::string& shapes_file, const std::string& output_path)
 {
     ch::CombineHarvester harvester;
 
-    for(const auto& channel : channels) {
+    for(const auto& channel : desc.channels) {
         const auto& ch_categories = GetChannelCategories(channel);
         harvester.AddObservations(wildcard, ana_name, eras, {channel}, ch_categories);
-        harvester.AddProcesses(masses_str, ana_name, eras, {channel}, signal_processes, ch_categories, true);
+        harvester.AddProcesses(desc.signal_points, ana_name, eras, {channel}, signal_processes, ch_categories, true);
         harvester.AddProcesses(wildcard, ana_name, eras, {channel}, bkg_all_processes, ch_categories, false);
     }
 
     AddSystematics(harvester);
-    ExtractShapes(harvester, shapes_path, false);
-    ExtractShapes(harvester, shapes_path, true);
+    ExtractShapes(harvester, shapes_file, false);
+    ExtractShapes(harvester, shapes_file, true);
+    if(desc.model_signal_process.size())
+        RenameProcess(harvester, desc.signal_process, desc.model_signal_process);
 
+    FixNegativeBins(harvester);
     harvester.cp().backgrounds().MergeBinErrors(bbb_unc_threshold, bin_merge_threashold);
     harvester.cp().backgrounds().AddBinByBin(bbb_unc_threshold, true, &harvester);
+    ch::SetStandardBinNames(harvester);
 
-    for(const auto& channel : channels) {
-        const std::string channel_path = FullPath({output_path, channel});
-        boost::filesystem::create_directories(channel_path);
+    std::shared_ptr<RooWorkspace> workspace;
+    RooRealVar mH("mH", "mH", Parse<double>(desc.signal_points.front()), Parse<double>(desc.signal_points.back()));
+    std::string output_pattern = "/$TAG/$MASS/$BIN.txt";
+    if(desc.morph) {
+        workspace = std::make_shared<RooWorkspace>("hh_ttbb", "hh_ttbb");
+        for(const auto& bin : harvester.bin_set())
+            ch::BuildRooMorphing(*workspace, harvester, bin, desc.model_signal_process, mH, "norm", true, true, true);
+        harvester.AddWorkspace(*workspace);
+        harvester.cp().process({desc.model_signal_process}).ExtractPdfs(harvester, workspace->GetName(),
+                                                                        "$BIN_$PROCESS_morph");
+        output_pattern = "/$TAG/$BIN.txt";
+    }
 
-        const std::string root_file_name = boost::str(boost::format("hh_bbtt_%1%.input.root") % channel);
-
-        const std::string root_file_full_name = FullPath({channel_path, root_file_name});
-        auto root_file = CreateRootFile(root_file_full_name);
-
-        for(const auto& mass : masses_str) {
-            const std::string mass_path = FullPath({channel_path, mass});
-            boost::filesystem::create_directories(mass_path);
-            const std::string root_file_link_name = FullPath({mass_path, root_file_name});
-            boost::filesystem::create_symlink(root_file_full_name, root_file_link_name);
-
-            const v_str mass_pattern = { mass, wildcard.front() };
-            for(const auto& category : harvester.cp().channel({channel}).bin_set()) {
-                const std::string datacard_name = boost::str(boost::format("%1%.txt") % category);
-                const std::string datacard_path = FullPath({mass_path, datacard_name});
-                harvester.cp().channel({channel}).mass(mass_pattern).bin({category})
-                        .WriteDatacard(datacard_path, *root_file);
-            }
-        }
+    ch::CardWriter writer(output_path + output_pattern, output_path + "/$TAG/hh_ttbb_input.root");
+    if(desc.morph)
+        writer.SetWildcardMasses({});
+    if(desc.combine_channels)
+        writer.WriteCards("cmb", harvester);
+    if(desc.per_channel_limits) {
+        for(const auto& chn : desc.channels)
+            writer.WriteCards(chn, harvester.cp().channel({chn}));
     }
 }
 
@@ -118,18 +110,15 @@ void bbtautau_Resonant::AddSystematics(ch::CombineHarvester& cb)
 {
     using ch::syst::SystMap;
     ch::CombineHarvester h = cb.cp();
-    const auto& sig = ch::Set2Vec(cb.cp().signals().process_set());
-    const std::vector<std::string> bkg_mc = {"TT", "ZTT", /*"VV", */"W"};
-    const std::vector<std::string> mc_samples = ch::JoinStr({ sig, {"TT", "ZTT", /*"VV", */"W"}});
 
-    h.cp().process(mc_samples).AddSyst(cb, "lumi_13TeV", "lnN", SystMap<>::init(1.027));
-    h.cp().process(sig).AddSyst(cb, "scale_j_13TeV", "lnN", SystMap<>::init(1.02));
-    h.cp().process(bkg_mc).AddSyst(cb, "scale_j_13TeV", "lnN", SystMap<>::init(1.04));
+    h.cp().process(all_mc_processes).AddSyst(cb, "lumi_13TeV", "lnN", SystMap<>::init(1.027));
+    h.cp().process(signal_processes).AddSyst(cb, "scale_j_13TeV", "lnN", SystMap<>::init(1.02));
+    h.cp().process(bkg_mc_processes).AddSyst(cb, "scale_j_13TeV", "lnN", SystMap<>::init(1.04));
     h.cp().process({"TT"}).AddSyst(cb, "TT_xs_13TeV", "lnN", SystMap<>::init(1.05));
-    h.cp().process(mc_samples).AddSyst(cb, "scale_b", "lnN", SystMap<>::init(1.02));
-    h.cp().process(mc_samples).AddSyst(cb, "eff_btag", "lnN", SystMap<>::init(1.03));
-    h.cp().process(mc_samples).AddSyst(cb, "eff_t", "lnN", SystMap<>::init(1.06));
-    h.cp().process(mc_samples).AddSyst(cb, "eff_m", "lnN", SystMap<>::init(1.018));
+    h.cp().process(all_mc_processes).AddSyst(cb, "scale_b", "lnN", SystMap<>::init(1.02));
+    h.cp().process(all_mc_processes).AddSyst(cb, "eff_btag", "lnN", SystMap<>::init(1.03));
+    h.cp().process(all_mc_processes).AddSyst(cb, "eff_t", "lnN", SystMap<>::init(1.06));
+    h.cp().process(all_mc_processes).AddSyst(cb, "eff_m", "lnN", SystMap<>::init(1.018));
     h.cp().process({"QCD"}).AddSyst(cb, "qcd_norm", "lnN", SystMap<>::init(1.06));
 }
 

--- a/StatModels/src/bbtautau_Resonant.cc
+++ b/StatModels/src/bbtautau_Resonant.cc
@@ -10,7 +10,7 @@ This file is part of https://github.com/cms-hh/StatAnalysis. */
 namespace hh_analysis {
 namespace stat_models {
 
-const std::string bbtautau_Resonant::file_name_suffix = "m_ttbb_MassWindow";
+const std::string bbtautau_Resonant::file_name_suffix = "m_ttbb_kinfit_KinFitConvergedWithMassWindow";
 const StatModel::v_double bbtautau_Resonant::masses = {
     250, 260, 270, 280, 320, 340, 450, 500, 550, 600, 650, 700,750, 800, 900
 };

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# Install cms-hh framework.
+# This file is part of https://github.com/cms-hh/HHStatAnalysis.
+
+INSTALL_MODES=(full plotting)
+DEFAULT_MODE=full
+DEFAULT_N_JOBS=8
+DEFAULT_RELEASE="CMSSW_7_4_7"
+
+function join_by { local d=$1; shift; echo -n "$1"; shift; printf "%s" "${@/#/$d}"; }
+
+if [ $# -gt 3 -o "x$1" = "x-h" -o "x$1" = "x--help" ] ; then
+    echo "Usage: [mode] [n_jobs] [cmssw_release]"
+    printf "\n\tmode\t\t\tinstallation mode. Supported modes: "
+    join_by ", " "${INSTALL_MODES[@]}"
+    printf ". Default: $DEFAULT_MODE."
+    printf "\n\tn_jobs\t\t\tthe number of jobs to run simultaneous during the compilation. Default: $DEFAULT_N_JOBS.\n"
+    printf "\tcmssw_release\t\tCMSSW release."
+    printf " Default: $DEFAULT_RELEASE.\n"
+    exit 1
+fi
+
+MODE=$1
+if [ "x$MODE" = "x" ] ; then
+    MODE=$DEFAULT_MODE
+elif [[ ! ${INSTALL_MODES[@]} =~ $MODE ]] ; then
+    echo "ERROR: unsupported installation mode '$MODE'."
+    echo "Supported installation modes: ${INSTALL_MODES[@]}"
+    exit 1
+fi
+
+N_JOBS=$2
+if [ "x$N_JOBS" = "x" ] ; then N_JOBS=$DEFAULT_N_JOBS ; fi
+if ! [ $N_JOBS -eq $N_JOBS ] 2>/dev/null ; then
+    echo "ERROR: invalid number of jobs '$N_JOBS'."
+    exit 1
+fi
+
+RELEASE=$3
+if [ "x$RELEASE" = "x" ] ; then
+    RELEASE=$DEFAULT_RELEASE
+fi
+if [ -e $RELEASE ] ; then
+    echo "ERROR: Working area for $RELEASE already exists."
+    exit 1
+fi
+
+export SCRAM_ARCH=slc6_amd64_gcc491
+scramv1 project CMSSW $RELEASE
+RESULT=$?
+if [ $RESULT -ne 0 ] ; then
+    echo "ERROR: unable to create working area for CMSSW release '$RELEASE'."
+    exit 2
+fi
+
+cd $RELEASE/src
+eval `scramv1 runtime -sh`
+RESULT=$?
+if [ $RESULT -ne 0 ] ; then
+    echo "ERROR: unable to setup the environment for CMSSW release '$RELEASE'."
+    exit 2
+fi
+
+if [ $MODE = "full" ] ; then
+    # Combine tool
+    git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
+    cd HiggsAnalysis/CombinedLimit
+    git checkout v6.3.0
+    cd ../..
+
+    # CombineHarvester package
+    mkdir CombineHarvester
+    cd CombineHarvester
+    git init
+    git remote add origin git@github.com:cms-analysis/CombineHarvester.git
+    git config core.sparsecheckout true
+    echo -e "CombineTools/\nCombinePdfs/" >> .git/info/sparse-checkout
+    git pull origin master
+    cd ..
+
+    # HHStatAnalysis package
+    git clone -o cms-hh git@github.com:cms-hh/HHStatAnalysis.git
+else
+    # HHStatAnalysis package
+    mkdir HHStatAnalysis
+    cd HHStatAnalysis
+    git init
+    git remote add cms-hh git@github.com:cms-hh/HHStatAnalysis.git
+    git config core.sparsecheckout true
+    echo -e "Core/" >> .git/info/sparse-checkout
+    git pull cms-hh master
+    cd ..
+fi
+
+git clone -o cms-hh git@github.com:cms-hh/Plotting.git HHStatAnalysis/Plotting
+git clone -o cms-hh git@github.com:cms-hh/Resources.git HHStatAnalysis/Resources
+
+GITHUB_USER=$(git config user.github)
+if ! [ "x$GITHUB_USER" = "x" ] ; then
+    cd HHStatAnalysis
+    git remote add $GITHUB_USER git@github.com:$GITHUB_USER/HHStatAnalysis.git
+    git fetch $GITHUB_USER
+    cd ..
+
+    cd HHStatAnalysis/Plotting
+    git remote add $GITHUB_USER git@github.com:$GITHUB_USER/Plotting.git
+    git fetch $GITHUB_USER
+    cd ../..
+
+    cd HHStatAnalysis/Resources
+    git remote add $GITHUB_USER git@github.com:$GITHUB_USER/Resources.git
+    git fetch $GITHUB_USER
+    cd ../..
+fi
+
+scram b -j$N_JOBS


### PR DESCRIPTION
- Moved commonly used code from Plotting repository into Core/interface.
- Several improvements in Core/interface functionality
- run_hh_limits.py: re-implemented in python the script to run HH limits.
- General review of StatModels code.
- Implemented configuration based on ConfigReader.h interfaces (similar to the one used for the plotting tool).
- Added support for model-dependent resonant limits.
- Added C++ to Python interface for StatModels library.
- Introduced installation script to facilitate the framework instalation.
- Updated documentation.