### PR TITLE
StatModel code refactoring and ttbb model updates.

### DIFF
--- a/Core/interface/Tools.h
+++ b/Core/interface/Tools.h
@@ -35,6 +35,42 @@ std::vector<Type> join_vectors(const std::vector< const std::vector<Type>* >& in
 }
 
 template<typename Type>
+void put_back(std::vector<Type>& v) { }
+
+template<typename Type, typename T2, typename ...Args>
+void put_back(std::vector<Type>& v, const T2& t, const Args&... args);
+
+template<typename Type, typename T2, typename ...Args>
+void put_back(std::vector<Type>& v, const std::vector<T2>& v2, const Args&... args)
+{
+    v.insert(v.end(), v2.begin(), v2.end());
+    put_back(v, args...);
+}
+
+template<typename Type, typename T2, typename ...Args>
+void put_back(std::vector<Type>& v, const T2& t, const Args&... args)
+{
+    v.push_back(t);
+    put_back(v, args...);
+}
+
+template<typename Type, typename ...Args>
+std::vector<Type> join(const Type& t, const Args&... args)
+{
+    std::vector<Type> result;
+    put_back(result, t, args...);
+    return result;
+}
+
+template<typename Type, typename ...Args>
+std::vector<Type> join(const std::vector<Type>& v, const Args&... args)
+{
+    std::vector<Type> result;
+    put_back(result, v, args...);
+    return result;
+}
+
+template<typename Type>
 std::set<Type> union_sets(std::initializer_list<std::set<Type>> sets)
 {
     std::set<Type> result;

--- a/Run2_2016/interface/CommonUncertainties.h
+++ b/Run2_2016/interface/CommonUncertainties.h
@@ -19,22 +19,24 @@ namespace Run2_2016 {
 struct CommonUncertainties {
 
     // LHC uncertainties
-    UNC(lumi, LHC, lnN, 1.058)
-    UNC(cr_DiBoson, LHC, lnN, 1.1)
-    UNC(cr_TTbar, LHC, lnN, 1.05)
-    UNC(cr_SM_HH, LHC, lnN, 1.08)
-    UNC(br_SM_H_bb, LHC, lnN, 1.0065)
-    UNC(br_SM_H_tautau, LHC, lnN, 1.0117)
+    UNC(lumi, LHC, lnN, 0.026) // LUM-17-001
+    UNC(QCDscale_VV, LHC, lnN, 0.04)
+    UNC(QCDscale_EWK, LHC, lnN, 0.04)
+    UNC(QCDscale_ttbar, LHC, lnN, +0.048, -0.055) // scale & PDF+alpha_s https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO
+    UNC(QCDscale_ggHH, LHC, lnN, +0.043, -0.060) // scale https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHXSWGHH
+    UNC(pdf_ggHH, LHC, lnN, 0.059) // Th & PDF & alpha_s https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHXSWGHH
+    UNC(BR_SM_H_bb, LHC, lnN, 0.013) // TH & m_q & alpha_s @ mH=125.09GeV https://twiki.cern.ch/twiki/bin/view/LHCPhysics/CERNYellowReportPageBR
+    UNC(BR_SM_H_tautau, LHC, lnN, 0.016) // TH & m_q & alpha_s @ mH=125.09GeV https://twiki.cern.ch/twiki/bin/view/LHCPhysics/CERNYellowReportPageBR
 
     // CMS uncertainties
-    UNC(scale_j, Experiment, lnN)
+    UNC(scale_j, Experiment, shape)
     UNC(res_j, Experiment, shape)
-    UNC(scale_b, Experiment, lnN, 1.02)
-    UNC(eff_btag, Experiment, lnN)
-    UNC(eff_e, Experiment, lnN)
-    UNC(eff_mu, Experiment, lnN)
-    UNC(eff_tau, Experiment, lnN)
-    UNC(scale_tau, Experiment, shape)
+    UNC(scale_b, Experiment, lnN, 0.02)
+    UNC(eff_b, Experiment, lnN)
+    UNC(eff_e, Experiment, lnN, 0.03)
+    UNC(eff_m, Experiment, lnN, 0.02)
+    UNC(eff_t, Experiment, lnN, 0.06)
+    UNC(scale_t, Experiment, shape)
     UNC(topPt, Experiment, shape)
 };
 

--- a/Run2_2016/interface/bbbb_nonresonant.h
+++ b/Run2_2016/interface/bbbb_nonresonant.h
@@ -15,16 +15,15 @@ public:
     static const v_str eras;
     static const v_str bkg_processes;
 
-    bbbb_nonresonant(const StatModelDescriptor& _desc);
-    virtual void CreateDatacards(const std::string& shapes_file, const std::string& output_path) override;
+    bbbb_nonresonant(const StatModelDescriptor& _desc, const std::string& input_file_name);
+    virtual void CreateDatacards(const std::string& output_path) override;
 
 private:
-    using ShapeNameRule = std::pair<std::string, std::string>;
-    static std::string NumToName(double x);
-    ShapeNameRule BackgroundShapeNameRule() const;
-    ShapeNameRule SignalShapeNameRule(double point_value) const;
-    void ExtractShapes(ch::CombineHarvester& combine_harvester, const std::string& shapes_file, bool is_signal) const;
-    ch::Categories GetChannelCategories(const std::string& channel);
+    virtual const v_str& SignalProcesses() const override { return signal_processes; }
+    virtual const v_str& BackgroundProcesses() const override { return bkg_processes; }
+
+    virtual ShapeNameRule SignalShapeNameRule() const override { return "$PROCESS"; }
+    virtual ShapeNameRule BackgroundShapeNameRule() const override { return "$PROCESS"; }
 
     void AddSystematics(ch::CombineHarvester& combine_harvester);
 

--- a/Run2_2016/interface/ttbb.h
+++ b/Run2_2016/interface/ttbb.h
@@ -4,6 +4,7 @@ This file is part of https://github.com/cms-hh/HHStatAnalysis. */
 #pragma once
 
 #include "HHStatAnalysis/StatModels/interface/StatModel.h"
+#include "HHStatAnalysis/StatModels/interface/ShapeNameRule.h"
 
 namespace hh_analysis {
 namespace stat_models {
@@ -13,21 +14,26 @@ class ttbb_base : public StatModel {
 public:
     static const v_str ana_name;
     static const v_str eras;
-    static const v_str bkg_mc_processes;
-    static const v_str bkg_data_driven_processes;
-    static const v_str bkg_all_processes;
+    static const std::string bkg_TT, bkg_tW, bkg_W, bkg_EWK, bkg_ZH, bkg_QCD, bkg_DY_0b, bkg_DY_1b, bkg_DY_2b;
+    static const v_str bkg_DY, bkg_VV;
+    static const v_str bkg_pure_MC, bkg_MC, bkg_all;
 
     static constexpr double bbb_unc_threshold = 0.1;
     static constexpr double bin_merge_threashold = 0.5;
 
-    ttbb_base(const StatModelDescriptor& _desc);
+    ttbb_base(const StatModelDescriptor& _desc, const std::string& input_file_name);
 
 protected:
     virtual void AddSystematics(ch::CombineHarvester& combine_harvester);
-    ch::Categories GetChannelCategories(const std::string& channel);
+
+    virtual const v_str& SignalProcesses() const override { return signal_processes; }
+    virtual const v_str& BackgroundProcesses() const override { return bkg_all; }
+
+    virtual ShapeNameRule SignalShapeNameRule() const override { return "$BIN/$PROCESS_$PREFIX$POINT"; }
+    virtual ShapeNameRule BackgroundShapeNameRule() const override { return "$BIN/$PROCESS"; }
 
 protected:
-    const v_str signal_processes, all_mc_processes;
+    const v_str signal_processes, all_mc_processes, all_processes;
 };
 
 } // namespace Run2_2016

--- a/Run2_2016/interface/ttbb_nonresonant.h
+++ b/Run2_2016/interface/ttbb_nonresonant.h
@@ -12,17 +12,10 @@ namespace Run2_2016 {
 class ttbb_nonresonant : public ttbb_base {
 public:
     using ttbb_base::ttbb_base;
-    virtual void CreateDatacards(const std::string& shapes_file, const std::string& output_path) override;
+    virtual void CreateDatacards(const std::string& output_path) override;
 
 protected:
     virtual void AddSystematics(ch::CombineHarvester& combine_harvester) override;
-
-private:
-    using ShapeNameRule = std::pair<std::string, std::string>;
-    static std::string NumToName(double x);
-    ShapeNameRule BackgroundShapeNameRule() const;
-    ShapeNameRule SignalShapeNameRule(double point_value) const;
-    void ExtractShapes(ch::CombineHarvester& combine_harvester, const std::string& shapes_file, bool is_signal) const;
 };
 
 } // namespace Run2_2016

--- a/Run2_2016/interface/ttbb_resonant.h
+++ b/Run2_2016/interface/ttbb_resonant.h
@@ -12,12 +12,7 @@ namespace Run2_2016 {
 class ttbb_resonant : public ttbb_base {
 public:
     using ttbb_base::ttbb_base;
-
-    virtual void CreateDatacards(const std::string& shapes_file, const std::string& output_path) override;
-
-private:
-    std::pair<std::string, std::string> ShapeNameRule(bool use_mass) const;
-    void ExtractShapes(ch::CombineHarvester& combine_harvester, const std::string& shapes_file, bool is_signal) const;
+    virtual void CreateDatacards(const std::string& output_path) override;
 };
 
 } // namespace Run2_2016

--- a/Run2_2016/src/export.cc
+++ b/Run2_2016/src/export.cc
@@ -5,14 +5,14 @@ This file is part of https://github.com/cms-hh/StatAnalysis. */
 #include "HHStatAnalysis/Run2_2016/interface/ttbb_nonresonant.h"
 #include "HHStatAnalysis/Run2_2016/interface/bbbb_nonresonant.h"
 
-#define MAKE_MODEL(model) if(name == #model) return std::make_shared<model>(*model_descriptor)
+#define MAKE_MODEL(model) if(name == #model) return std::make_shared<model>(*model_descriptor, shapes_file_name)
 
-extern "C" hh_analysis::stat_models::StatModelPtr create_stat_model(
-        const char* stat_model_name, const hh_analysis::StatModelDescriptor* model_descriptor)
+extern "C" hh_analysis::stat_models::StatModelPtr create_stat_model(const char* stat_model_name,
+                const hh_analysis::StatModelDescriptor* model_descriptor, const char* shapes_file_name)
 {
     using namespace hh_analysis::stat_models::Run2_2016;
 
-    if(!stat_model_name || !model_descriptor)
+    if(!stat_model_name || !model_descriptor || !shapes_file_name)
         throw analysis::exception("Null pointer is passed to create_stat_model function.");
 
     const std::string name(stat_model_name);

--- a/StatModels/bin/create_hh_datacards.cpp
+++ b/StatModels/bin/create_hh_datacards.cpp
@@ -40,12 +40,12 @@ public:
         auto creator = (stat_models::StatModelCreator) dlsym(handle, creator_fn_name.c_str());
         if(!creator)
             throw exception("Unable to load %1% function from %2%.") % creator_fn_name % library_name;
-        auto model = creator(stat_model_name.c_str(), &model_desc);
+        auto model = creator(stat_model_name.c_str(), &model_desc, args.shapes().c_str());
         if(!model)
             throw exception("Unable to create an object for stat model '%1%'.") % model_desc.stat_model;
         std::cout << boost::format("Creating datacards for %1% unc model using %2% shapes...")
                      % model_desc.stat_model % args.shapes() << std::endl;
-        model->CreateDatacards(args.shapes(), args.output_path());
+        model->CreateDatacards(args.output_path());
         std::cout << boost::format("Datacards are successfully created into '%1%'.") % args.output_path() << std::endl;
     }
 

--- a/StatModels/interface/ModelConfigEntryReader.h
+++ b/StatModels/interface/ModelConfigEntryReader.h
@@ -34,6 +34,8 @@ public:
         CheckReadParamCounts("blind", 1, Condition::less_equal);
         CheckReadParamCounts("morph", 1, Condition::less_equal);
         CheckReadParamCounts("combine_channels", 1, Condition::less_equal);
+        CheckReadParamCounts("per_channel_limits", 1, Condition::less_equal);
+        CheckReadParamCounts("per_category_limits", 1, Condition::less_equal);
         CheckReadParamCounts("grid_x", 1, Condition::less_equal);
         CheckReadParamCounts("grid_y", 1, Condition::less_equal);
 
@@ -56,6 +58,7 @@ public:
         ParseEntry("morph", current.morph);
         ParseEntry("combine_channels", current.combine_channels);
         ParseEntry("per_channel_limits", current.per_channel_limits);
+        ParseEntry("per_category_limits", current.per_category_limits);
         ParseEntry("grid_x", current.grid_x);
         ParseEntry("grid_y", current.grid_y);
         ParseEntry("custom_param", current.custom_params);

--- a/StatModels/interface/PhysicalConstants.h
+++ b/StatModels/interface/PhysicalConstants.h
@@ -1,0 +1,19 @@
+/*! Definition of physical constants used in HH analyses.
+This file is part of https://github.com/cms-hh/HHStatAnalysis. */
+
+#pragma once
+
+namespace hh_analysis {
+namespace phys_const {
+
+constexpr double pb = 1;
+constexpr double fb = 1e-3;
+
+constexpr double BR_H_tautau = 6.256e-02;
+constexpr double BR_H_bb = 5.809e-01;
+constexpr double BR_HH_bbbb = BR_H_bb * BR_H_bb;
+constexpr double BR_HH_bbtautau = 2 * BR_H_tautau * BR_H_bb;
+constexpr double XS_HH_13TeV = 33.41 * fb;
+
+} // namespace phys_const
+} // namespace hh_analysis

--- a/StatModels/interface/ShapeNameRule.h
+++ b/StatModels/interface/ShapeNameRule.h
@@ -1,0 +1,49 @@
+/*! Definition of the class that represents shape name rule.
+This file is part of https://github.com/cms-hh/HHStatAnalysis. */
+
+#pragma once
+
+#include "Uncertainty.h"
+
+namespace hh_analysis {
+
+class ShapeNameRule {
+public:
+    static const std::string Analysis, Channel, Bin, Process, Point, Mass, Era, Systematic, Category, Region, Prefix;
+    static const std::set<std::string> AllVariables;
+
+    static std::string NumToName(double x);
+    static std::string BinName(const std::string& channel, const std::string& category, const std::string& region = "");
+    static std::string AddDimSuffix(const std::string& variable, size_t dim = 0);
+
+    ShapeNameRule() {}
+    ShapeNameRule(const char* _rule) : rule(_rule) {}
+    ShapeNameRule(const std::string& _rule) : rule(_rule) {}
+    operator std::string() const { return rule; }
+    const std::string& GetRule() const { return rule; }
+
+    bool HasVariables() const { return rule.find('$') != std::string::npos; }
+    ShapeNameRule SetVariable(const std::string& variable, const std::string& value) const;
+
+    ShapeNameRule SetAnalysis(const std::string& analysis) const { return SetVariable(Analysis, analysis); }
+    ShapeNameRule SetChannel(const std::string& channel) const { return SetVariable(Channel, channel); }
+    ShapeNameRule SetProcess(const std::string& process) const { return SetVariable(Process, process); }
+    ShapeNameRule SetEra(const std::string& era) const { return SetVariable(Era, era); }
+    ShapeNameRule SetCategory(const std::string& category) const { return SetVariable(Category, category); }
+    ShapeNameRule SetRegion(const std::string& region) const { return SetVariable(Region, region); }
+
+    ShapeNameRule SetBin(const std::string& bin) const { return SetVariable(Bin, bin); }
+    ShapeNameRule SetBin(const std::string& channel, const std::string& category, const std::string& region = "") const;
+
+    ShapeNameRule SetPrefix(const std::string& prefix, size_t dim = 0) const;
+    ShapeNameRule SetPoint(double point, size_t dim = 0) const;
+    ShapeNameRule SetMass(double mass) const { return SetVariable(Mass, NumToName(mass)); }
+
+    ShapeNameRule AddSystematicVariable() const;
+    ShapeNameRule SetSystematic(const std::string& systematic, UncVariation variation) const;
+
+private:
+    std::string rule;
+};
+
+} // namespace hh_analysis

--- a/StatModels/interface/StatModel.h
+++ b/StatModels/interface/StatModel.h
@@ -4,33 +4,68 @@ This file is part of https://github.com/cms-hh/HHStatAnalysis. */
 #pragma once
 
 #include "CombineHarvester/CombineTools/interface/CombineHarvester.h"
+#include "HHStatAnalysis/Core/interface/RootExt.h"
 #include "StatModelDescriptor.h"
+#include "ShapeNameRule.h"
 
 namespace hh_analysis {
 namespace stat_models {
+
+struct Yield {
+    double value, error;
+    Yield() : value(0), error(0) {}
+    Yield(double _value, double _error) : value(_value), error(_error) {}
+};
 
 class StatModel {
 public:
     using v_str = std::vector<std::string>;
     using v_double = std::vector<double>;
+    using Hist = TH1;
+    using Hist2D = TH2;
 
     static const v_str wildcard;
 
-    StatModel(const StatModelDescriptor& _desc) : desc(_desc) {}
+    StatModel(const StatModelDescriptor& _desc, const std::string& input_file_name);
 
     virtual ~StatModel() {}
-    virtual void CreateDatacards(const std::string& shapes_file, const std::string& output_path) = 0;
+    virtual void CreateDatacards(const std::string& output_path) = 0;
+
+protected:
 
     static void FixNegativeBins(ch::CombineHarvester& harvester);
     static void RenameProcess(ch::CombineHarvester& harvester, const std::string& old_name,
                               const std::string& new_name);
 
+    virtual const v_str& SignalProcesses() const = 0;
+    virtual const v_str& BackgroundProcesses() const = 0;
+
+    virtual ShapeNameRule SignalShapeNameRule() const = 0;
+    virtual ShapeNameRule BackgroundShapeNameRule() const = 0;
+
+    virtual ch::Categories GetChannelCategories(const std::string& channel);
+    virtual void ExtractShapes(ch::CombineHarvester& cb) const;
+
+    template<typename T>
+    const T* ReadObject(const std::string& name) const { return root_ext::ReadObject<T>(*input_file, name); }
+    virtual const Hist* GetSignalHistogram(const std::string& process, double point, const std::string& channel,
+                                           const std::string& category, const std::string& region = "") const;
+    virtual const Hist* GetBackgroundHistogram(const std::string& process, const std::string& channel,
+                                               const std::string& category, const std::string& region = "") const;
+
+    static Yield GetYield(const Hist& hist);
+    Yield GetSignalYield(const std::string& process, double point, const std::string& channel,
+                         const std::string& category, const std::string& region = "") const;
+    Yield GetBackgroundYield(const std::string& process, const std::string& channel,
+                             const std::string& category, const std::string& region = "") const;
+
 protected:
     StatModelDescriptor desc;
+    std::shared_ptr<TFile> input_file;
 };
 
 using StatModelPtr = std::shared_ptr<StatModel>;
-using StatModelCreator = StatModelPtr (*)(const char*, const StatModelDescriptor*);
+using StatModelCreator = StatModelPtr (*)(const char*, const StatModelDescriptor*, const char*);
 
 } // namespace stat_models
 } // namespace hh_analysis

--- a/StatModels/interface/StatModelDescriptor.h
+++ b/StatModels/interface/StatModelDescriptor.h
@@ -30,7 +30,7 @@ struct StatModelDescriptor {
 
     LimitType limit_type;
     std::string th_model_file;
-    bool blind, morph, combine_channels, per_channel_limits;
+    bool blind, morph, combine_channels, per_channel_limits, per_category_limits;
     RangeWithStep<double> grid_x, grid_y;
 
 
@@ -50,7 +50,7 @@ struct StatModelDescriptor {
 
     StatModelDescriptor() :
         limit_type(LimitType::ModelIndependent), blind(true), morph(false), combine_channels(true),
-        per_channel_limits(false) {}
+        per_channel_limits(false), per_category_limits(false) {}
 };
 
 using ModelDescriptorCollection = std::unordered_map<std::string, StatModelDescriptor>;

--- a/StatModels/src/ShapeNameRule.cc
+++ b/StatModels/src/ShapeNameRule.cc
@@ -1,0 +1,89 @@
+/*! Definition of the class that represents shape name rule.
+This file is part of https://github.com/cms-hh/HHStatAnalysis. */
+
+#include "HHStatAnalysis/StatModels/interface/ShapeNameRule.h"
+
+namespace hh_analysis {
+
+const std::string ShapeNameRule::Analysis = "$ANALYSIS";
+const std::string ShapeNameRule::Channel = "$CHANNEL";
+const std::string ShapeNameRule::Bin = "$BIN";
+const std::string ShapeNameRule::Process = "$PROCESS";
+const std::string ShapeNameRule::Point = "$POINT";
+const std::string ShapeNameRule::Mass = "$MASS";
+const std::string ShapeNameRule::Era = "$ERA";
+const std::string ShapeNameRule::Systematic = "$SYSTEMATIC";
+const std::string ShapeNameRule::Category = "$CATEGORY";
+const std::string ShapeNameRule::Region = "$REGION";
+const std::string ShapeNameRule::Prefix = "$PREFIX";
+
+const std::set<std::string> ShapeNameRule::AllVariables = {
+    Analysis, Channel, Bin, Process, Point, Mass, Era, Systematic, Category, Region, Prefix
+};
+
+std::string ShapeNameRule::NumToName(double x)
+{
+    std::ostringstream ss;
+    ss << x;
+    std::string str = ss.str();
+    std::replace(str.begin(), str.end(), '-', 'm');
+    std::replace(str.begin(), str.end(), '.', 'p');
+    return str;
+}
+
+std::string ShapeNameRule::BinName(const std::string& channel, const std::string& category, const std::string& region)
+{
+    std::ostringstream bin;
+    bin << channel << "_" << category;
+    if(region.size())
+        bin << "_" << region;
+    return bin.str();
+}
+
+std::string ShapeNameRule::AddDimSuffix(const std::string& variable, size_t dim)
+{
+    std::ostringstream var;
+    var << variable;
+    if(dim > 0)
+        var << dim;
+    return var.str();
+}
+
+ShapeNameRule ShapeNameRule::SetVariable(const std::string& variable, const std::string& value) const
+{
+    std::string new_rule = rule;
+    boost::replace_all(new_rule, variable, value);
+    return ShapeNameRule(new_rule);
+}
+
+ShapeNameRule ShapeNameRule::SetBin(const std::string& channel, const std::string& category,
+                                    const std::string& region) const
+{
+    return SetBin(BinName(channel, category, region));
+}
+
+ShapeNameRule ShapeNameRule::SetPrefix(const std::string& prefix, size_t dim) const
+{
+    return SetVariable(AddDimSuffix(Prefix, dim), prefix);
+}
+
+ShapeNameRule ShapeNameRule::SetPoint(double point, size_t dim) const
+{
+    return SetVariable(AddDimSuffix(Point, dim), NumToName(point));
+}
+
+ShapeNameRule ShapeNameRule::AddSystematicVariable() const
+{
+    std::ostringstream new_rule;
+    new_rule << rule << "_" << Systematic;
+    return ShapeNameRule(new_rule.str());
+}
+
+ShapeNameRule ShapeNameRule::SetSystematic(const std::string& systematic, UncVariation variation) const
+{
+    std::ostringstream value;
+    value << systematic << variation;
+    return SetVariable(Systematic, value.str());
+}
+
+} // namespace hh_analysis

--- a/StatModels/src/StatModel.cc
+++ b/StatModels/src/StatModel.cc
@@ -8,6 +8,11 @@ namespace stat_models {
 
 const StatModel::v_str StatModel::wildcard = { "*" };
 
+StatModel::StatModel(const StatModelDescriptor& _desc, const std::string& input_file_name) :
+    desc(_desc), input_file(root_ext::OpenRootFile(input_file_name))
+{
+}
+
 void StatModel::FixNegativeBins(ch::CombineHarvester& harvester)
 {
     harvester.ForEachProc([](ch::Process *p) {
@@ -27,6 +32,73 @@ void StatModel::RenameProcess(ch::CombineHarvester& harvester, const std::string
     });
 }
 
+ch::Categories StatModel::GetChannelCategories(const std::string& channel)
+{
+    ch::Categories ch_categories;
+    for(size_t n = 0; n < desc.categories.size(); ++n) {
+        const std::string bin_name = ShapeNameRule::BinName(channel, desc.categories.at(n));
+        ch_categories.push_back({n, bin_name});
+    }
+    return ch_categories;
+}
+
+void StatModel::ExtractShapes(ch::CombineHarvester& cb) const
+{
+    const auto signal_rule = SignalShapeNameRule().SetPrefix(desc.signal_point_prefix);
+    for(const std::string& point_str : desc.signal_points) {
+        const double point = Parse<double>(point_str);
+        const auto point_rule = signal_rule.SetPoint(point);
+        cb.cp().process(SignalProcesses()).mass({point_str})
+               .ExtractShapes(input_file->GetName(), point_rule, point_rule.AddSystematicVariable());
+    }
+
+    const auto bkg_rule = BackgroundShapeNameRule();
+    cb.cp().process(BackgroundProcesses())
+           .ExtractShapes(input_file->GetName(), bkg_rule, bkg_rule.AddSystematicVariable());
+}
+
+const StatModel::Hist* StatModel::GetSignalHistogram(const std::string& process, double point,
+                                                     const std::string& channel, const std::string& category,
+                                                     const std::string& region) const
+{
+    const auto name_rule = SignalShapeNameRule().SetProcess(process).SetPrefix(desc.signal_point_prefix)
+                                                .SetPoint(point).SetBin(channel, category, region);
+    if(name_rule.HasVariables())
+        throw exception("Insufficient information to make full histogram name for signal process '%1%' at point %2%"
+                        " in bin '%3%'.") % process % point % ShapeNameRule::BinName(channel, category, region);
+    return ReadObject<Hist>(name_rule);
+}
+
+const StatModel::Hist* StatModel::GetBackgroundHistogram(const std::string& process, const std::string& channel,
+                                   const std::string& category, const std::string& region) const
+{
+    const auto name_rule = BackgroundShapeNameRule().SetProcess(process).SetBin(channel, category, region);
+    if(name_rule.HasVariables())
+        throw exception("Insufficient information to make full histogram name for background process '%1%'"
+                        " in bin '%2%'.") % process % ShapeNameRule::BinName(channel, category, region);
+    return ReadObject<Hist>(name_rule);
+}
+
+Yield StatModel::GetYield(const Hist& hist)
+{
+    Yield yield;
+    yield.value = hist.IntegralAndError(1, hist.GetNbinsX(), yield.error);
+    return yield;
+}
+
+Yield StatModel::GetSignalYield(const std::string& process, double point, const std::string& channel,
+                                const std::string& category, const std::string& region) const
+{
+    const auto hist = GetSignalHistogram(process, point, channel, category, region);
+    return GetYield(*hist);
+}
+
+Yield StatModel::GetBackgroundYield(const std::string& process, const std::string& channel,
+                                    const std::string& category, const std::string& region) const
+{
+    const auto hist = GetBackgroundHistogram(process, channel, category, region);
+    return GetYield(*hist);
+}
 
 } // namespace stat_models
 } // namespace hh_analysis


### PR DESCRIPTION
- Added optional impacts computation to run_hh_limits.
- Updated common uncertainties
- Created class ShapeNameRule
- Following @OlivierBondu suggestions, moved shape extraction code into StatModel, in order to remove code duplications.
- StatModel: added methods to load histogram and calculate its yield.
- Changed interface of StatModelCreator.
- Added possibility to run per-category limits.
- Moved definition of physical constants into a separate file.
- Modified LLR_convert_shapes.py to extract shape uncertainties.
- Reviewed ttbb model.